### PR TITLE
Add initial R script with most basic utility

### DIFF
--- a/start.R
+++ b/start.R
@@ -1,0 +1,39 @@
+library(surveillance)
+library(tidyverse)
+
+# turn data into sts object
+convert_to_sts <- function(data) {
+  # Convert the 'date_onset' column to a date format
+  data <- data %>%
+    dplyr::mutate(date_onset = as.Date(date_onset)) %>%
+    dplyr::arrange(date_onset)
+
+  year_week <- surveillance::isoWeekYear(data$date_onset)
+
+  # aggregate case counts per week
+  case_counts <- data %>%
+    dplyr::mutate(isoyear = year_week$ISOYear) %>%
+    dplyr::mutate(isoweek = year_week$ISOWeek) %>%
+    dplyr::group_by(isoyear, isoweek) %>%
+    dplyr::summarize(cases = n())
+
+  # create sts object
+  return(surveillance::sts(case_counts$cases,
+    start = c(
+      case_counts$isoyear[1],
+      case_counts$isoweek[1]
+    ),
+    frequency = 52
+  ))
+}
+
+# load example data
+input_path <- "data/input/input.csv"
+data <- read.csv(input_path, header = TRUE, sep = ",")
+
+sts_cases <- convert_to_sts(data)
+
+# run Farrington Flexible on data
+results <- surveillance::farringtonFlexible(sts_cases)
+
+print(results)


### PR DESCRIPTION
Added a first R script to satisfy requirements of the following issue: [Add initial R script](https://github.com/United4Surveillance/signal-detection-tool/issues/2).
There was no definite decision to use renv, hence it is not utilized here.
There also was no output defined yet. 

Execution of the script results in following error:

> Error in seq.default(dayToConsider, length.out = (b + 1), by = -freq) : 
>   'from' must be a finite number

This is because the data file that was used only includes cases for one week. This is not sufficient to test surveillance's farringtonFlexible.
Will need to wait for issue 12 ([Create a default data file for developing and testing](https://github.com/United4Surveillance/signal-detection-tool/issues/12)) before development can proceed.