### PR TITLE
Add functionality to analyse stratified data

### DIFF
--- a/R/farrington_flexible.R
+++ b/R/farrington_flexible.R
@@ -1,30 +1,28 @@
 library(surveillance)
 library(tidyverse)
 
-preprocess_data <- function(data){
-  
+preprocess_data <- function(data) {
   # Convert the date columns to date format
   data <- data %>%
-    dplyr::mutate(across(starts_with("date"), ~ as.Date(.x,optional=T)))
-  
+    dplyr::mutate(across(starts_with("date"), ~ as.Date(.x, optional = T)))
+
   # add columns for isoyear and isoweek for each date
   data <- data %>%
-    dplyr::mutate(across(starts_with("date")&!where(is.numeric), ~ surveillance::isoWeekYear(.x)$ISOYear, .names = "{.col}_year")) %>%
-    dplyr::mutate(across(starts_with("date")&!where(is.numeric), ~ surveillance::isoWeekYear(.x)$ISOWeek, .names = "{.col}_week"))
-  
+    dplyr::mutate(across(starts_with("date") & !where(is.numeric), ~ surveillance::isoWeekYear(.x)$ISOYear, .names = "{.col}_year")) %>%
+    dplyr::mutate(across(starts_with("date") & !where(is.numeric), ~ surveillance::isoWeekYear(.x)$ISOWeek, .names = "{.col}_week"))
+
   data
 }
 
 #' Aggregates case data by year and week of onset
 #' @param data data frame to be converged
-#' 
-#' @examples 
+#'
+#' @examples
 #' input_path <- "data/input/input.csv"
 #' data <- read.csv(input_path, header = TRUE, sep = ",")
 #' data <- preprocess_data(data) %>% aggregate_data()
 #' sts_cases <- convert_to_sts(data)
-aggregate_data <- function(data){
-  
+aggregate_data <- function(data) {
   data %>%
     dplyr::group_by(date_onset_year, date_onset_week) %>%
     dplyr::summarize(cases = n()) %>%
@@ -33,60 +31,157 @@ aggregate_data <- function(data){
 
 #' Turns aggregated data into surveillance's sts format
 #' @param case_counts case count data frame to be converted
-#' 
-#' @examples 
+#'
+#' @examples
 #' input_path <- "data/input/input.csv"
 #' data <- read.csv(input_path, header = TRUE, sep = ",")
 #' data <- preprocess_data(data) %>% aggregate_data()
 #' sts_cases <- convert_to_sts(data)
 convert_to_sts <- function(case_counts) {
-  
   # create sts object
   return(surveillance::sts(case_counts$cases,
-                           start = c(
-                             case_counts$year[1],
-                             case_counts$week[1]
-                           ),
-                           frequency = 52
+    start = c(
+      case_counts$year[1],
+      case_counts$week[1]
+    ),
+    frequency = 52
   ))
 }
 
+#' Add rows of missing dates to a Year-Week Data Frame
+#'
+#' This function takes a data frame containing year-week information and ensures
+#' that it includes all possible year-week combinations within the specified range.
+#' It fills in missing rows with 0 values for cases and returns the updated data frame.
+#'
+#' @param data A data frame with columns 'year' and 'week' representing the year and week
+#'             values for each observation.
+#' @param date_start A date object or character of format yyyy-mm-dd
+#' @param date_end A date object or character of format yyyy-mm-dd
+#'
+#' @return A data frame containing all year-week combinations within the input range,
+#'         with missing rows filled in with 0 values for cases.
+#'
+#' @examples
+#' data <- data.frame(year = c(2021, 2022, 2022), week = c(1, 2, 4), cases = c(10, 15, 5))
+#' # updated_data <- add_rows_missing_dates(data, "2022-01-21", "2023-05-01")
+#' updated_data <- add_rows_missing_dates(data)
+#' updated_data
+add_rows_missing_dates <- function(data, date_start=NULL, date_end=NULL) {
+  
+  checkmate::assert(
+    checkmate::check_choice("year", names(data)),
+    checkmate::check_choice("week", names(data)),
+    combine="and"
+  )
+  
+  checkmate::assert(
+    checkmate::check_null(date_start),
+    checkmate::check_date(lubridate::date(date_start)),
+    combine="or"
+  )
+  checkmate::assert(
+    checkmate::check_null(date_end),
+    checkmate::check_date(lubridate::date(date_end)),
+    combine="or"
+  )
+  
+  if(is.null(date_start)){
+    min_year_week <- min(data$year * 100 + data$week)
+  }
+  else{
+    min_year_week <- lubridate::isoyear(date_start) * 100 + lubridate::isoweek(date_start)
+  }
+  if(is.null(date_end)){
+    max_year_week <- max(data$year * 100 + data$week)  
+  }
+  else{
+    max_year_week <- lubridate::isoyear(date_end) * 100 + lubridate::isoweek(date_end)
+  }
+  
+
+  # Create a template data frame with all year-week combinations in specified timeframe
+  template <- expand.grid(
+    year = floor(min_year_week/100):floor(max_year_week/100),
+    week = 1:52
+  )
+
+  # Merge the template with the original data to fill in missing rows
+  result <- merge(data, template, by = c("year", "week"), all = TRUE) %>%
+    mutate(yearweek = year * 100 + week) %>%
+    filter((yearweek >= min_year_week) & (yearweek <= max_year_week)) %>%
+    select(-c(yearweek))
+
+  # Replace missing cases with 0
+  result$cases[is.na(result$cases)] <- 0
+
+  return(result)
+}
+
+
 #' Get signals of surveillance's farringtonFlexible algorithm
 #' @param data data frame to be converged
-#' 
-#' @examples 
+#' @param date_start A date object or character of format yyyy-mm-dd
+#' @param date_end A date object or character of format yyyy-mm-dd
+#'
+#' @examples
 #' input_path <- "data/input/input.csv"
 #' data <- read.csv(input_path, header = TRUE, sep = ",")
 #' results <- get_signals_farringtonflexible(data)
-get_signals_farringtonflexible <- function(surveillance_data){
+get_signals_farringtonflexible <- function(surveillance_data, 
+                                           date_start=NULL,
+                                           date_end=NULL) {
   
-  data <- preprocess_data(surveillance_data) %>% aggregate_data()
   
+  checkmate::assert(
+    checkmate::check_null(date_start),
+    checkmate::check_date(lubridate::date(date_start)),
+    combine="or"
+  )
+  checkmate::assert(
+    checkmate::check_null(date_end),
+    checkmate::check_date(lubridate::date(date_end)),
+    combine="or"
+  )
+  
+  data <- preprocess_data(surveillance_data) %>%
+    aggregate_data() %>%
+    add_rows_missing_dates(date_start, date_end)
+
   sts_cases <- convert_to_sts(data)
-  
+
   num_weeks <- length(sts_cases@observed)
-  num_years <- floor((num_weeks - 26)/52)-1
-  
-  control  <- list(range=((num_weeks-51):num_weeks),
-                   noPeriods=10,populationOffset=FALSE,
-                   fitFun="algo.farrington.fitGLM.flexible",
-                   b=num_years,w=3,weightsThreshold=2.58,
-                   pastWeeksNotIncluded=26,
-                   pThresholdTrend=1,trend=TRUE,
-                   thresholdMethod="delta",alpha=0.1)
-  
-  
+  num_years <- floor((num_weeks - 26) / 52) - 1
+
+  if (num_years <= 0) {
+    warning(paste0(
+      "Your input data/stratification only stretches over ", num_weeks,
+      " weeks. FarringtonFlexible needs at least a year of data to calibrate an epidemiological baseline."
+    ))
+    return(NULL)
+  }
+
+  control <- list(
+    range = ((num_weeks - 51):num_weeks),
+    noPeriods = 10, populationOffset = FALSE,
+    fitFun = "algo.farrington.fitGLM.flexible",
+    b = num_years, w = 3, weightsThreshold = 2.58,
+    pastWeeksNotIncluded = 26,
+    pThresholdTrend = 1, trend = TRUE,
+    thresholdMethod = "delta", alpha = 0.1
+  )
+
   # run Farrington Flexible on data
   results <- surveillance::farringtonFlexible(sts_cases, control)
-  
-  pad <- rep(NA,num_weeks-52)
-  alarms <- c(pad,results@alarm)
+
+  pad <- rep(NA, num_weeks - 52)
+  alarms <- c(pad, results@alarm)
   upperbound <- c(pad, results@upperbound)
   expected <- c(pad, results@control$expected)
-  
+
   data$alarms <- alarms
   data$upperbound <- upperbound
   data$expected <- expected
-  
+
   return(data)
 }

--- a/R/main.R
+++ b/R/main.R
@@ -9,11 +9,53 @@ library(tidyverse)
 source("tool_functions.R")
 source("farrington_flexible.R")
 
+#' Get Signals
+#'
+#' This function analyzes surveillance data to detect signals using the specified method.
+#'
+#' @param data A data frame containing the surveillance data.
+#' @param method The method to use for signal detection (currently supports "farrington").
+#' @param stratification A character vector specifying the columns to stratify the analysis. Default is NULL.
+#'
+#' @return A tibble containing the results of the signal detection analysis.
+#' @export
+#'
+#' @examples
+#' data <- read.csv("../data/input/input.csv")
+#' # results <- get_signals(data)
+#' results <- get_signals(data, method = "farrington", stratification = c("county", "sex"))
+get_signals <- function(data, method = "farrington", stratification = NULL) {
+  # check that input method and stratification are correct
+  checkmate::assert(
+    checkmate::check_choice(method, choices = c("farrington"))
+  )
+  checkmate::assert(
+    checkmate::check_null(stratification),
+    checkmate::check_vector(stratification),
+    combine = "or"
+  )
+
+  if (method == "farrington") {
+    fun <- get_signals_farringtonflexible
+  }
+
+  if (is.null(stratification)) {
+    results <- fun(data) %>% dplyr::mutate(category = NA, stratum = NA)
+  } else {
+    results <- get_signals_stratified(data, fun, stratification)
+  }
+
+  return(results)
+}
+
+
 # load example data
 input_path <- "../data/input/input.csv"
 data <- read.csv(input_path, header = TRUE, sep = ",")
 
-# run Farrington Flexible on data
-results <- get_signals_farringtonflexible(data)
+
+# run signal detection on data
+# results <- get_signals(data)  # no stratification
+results <- get_signals(data, stratification = c("county", "sex", "age_group"))
 
 print(results)

--- a/R/tool_functions.R
+++ b/R/tool_functions.R
@@ -4,13 +4,13 @@
 #' Finds correct age interval for given age
 #' @param age integer age in years
 #' @param x vector of age group break points
-#' 
-#' @example 
+#'
+#' @example
 #' find_age_group(5, c(0, 5, 10, 99))  # would result in "05-09"
 #' find_age_group(12, c(0, 5, 15, 99)) # would result in "05-14"
-find_age_group <- function(age, x) { 
+find_age_group <- function(age, x) {
   intervals <- length(x) # number of age groups
-  
+
   for (i in 1:intervals) { # finding interval in which age lies
     if (i == intervals) { # check if last age group
       group <- paste0(x[i], "+")
@@ -19,11 +19,11 @@ find_age_group <- function(age, x) {
     if ((x[i] <= age) & (age < x[i + 1])) {
       if (age < 10 | x[i] < 10) { # zero padding
         group <- paste(paste0(0, x[i]),
-                       ifelse(x[i + 1] - 1 < 10,
-                              paste0(0, x[i + 1] - 1),
-                              x[i + 1] - 1
-                       ),
-                       sep = "-"
+          ifelse(x[i + 1] - 1 < 10,
+            paste0(0, x[i + 1] - 1),
+            x[i + 1] - 1
+          ),
+          sep = "-"
         )
         return(group)
       } else {
@@ -37,8 +37,8 @@ find_age_group <- function(age, x) {
 #' Creates age grouping variable for a given data set
 #' @param df data frame on which the age grouping is created
 #' @param break_at integer that controls the length of the age groups
-#' 
-#' @example 
+#'
+#' @example
 #' input_path <- "data/input/input_sample.csv"
 #' data <- read.csv(input_path, header = TRUE, sep = ",")
 #' data$age <- sample(1:125, 10, replace = TRUE)
@@ -46,12 +46,12 @@ find_age_group <- function(age, x) {
 #' age_groups(data, c(15L,35L,65L,100L)) # custom age groups
 age_groups <- function(df, break_at = NULL) {
   # error checking ----------------------------------------------------------
-  
+
   if (!is.null(break_at)) { # check for non integer values
     if (!(is.integer(break_at))) {
       stop("Input of integer type is only allowed")
     }
-    
+
     var <- length(break_at) # helper vector
     for (i in 1:(var - 1)) { # check if break points are ordered
       if (break_at[i + 1] < break_at[i]) {
@@ -59,45 +59,101 @@ age_groups <- function(df, break_at = NULL) {
       }
     }
   }
-  
+
   # setting up age groups ---------------------------------------------------
-  
+
   default_break_at <- seq(5, 125, 5)
-  
+
   if (is.null(break_at)) { # use default age groups
     set <- c(0, default_break_at) # helper vector
   } else { # use custom age groups
     set <- c(0, break_at)
   }
-  
+
   # assigning age group  ----------------------------------------------------
-  
+
   for (i in 1:nrow(df)) { # assign age group to every age in data frame
-    
+
     if (is.integer(df$age) != TRUE) { # check for integer
       stop("Type of age is not integer")
     }
     df$age_group[i] <- find_age_group(df$age[i], set)
   }
-  
+
   # converting age_group to factor ------------------------------------------
-  
+
   # extract the lower values of age groups
   lower_values <- gsub("-.*", "", df$age_group)
   lower_values <- as.numeric(lower_values)
-  
+
   # order the age groups based on the lower values
   ordered_groups <- df$age_group[order(lower_values)]
-  
+
   df$age_group <- factor(df$age_group, levels = unique(ordered_groups))
   return(df)
 }
 
-#' Preprocesses date column and adds isoweek and isoyear columns
-#' @param data data frame to be converged
-#' 
-#' @examples 
-#' input_path <- "data/input/input.csv"
-#' data <- read.csv(input_path, header = TRUE, sep = ",")
-#' data <- preprocess_data(data) %>% aggregate_data()
-#' sts_cases <- convert_to_sts(data)
+#' Get Signals Stratified
+#'
+#' This function stratifies surveillance data by specified columns and analyzes each stratum separately using the specified method.
+#'
+#' @param data A data frame containing the surveillance data.
+#' @param fun The signal detection function to apply to each stratum.
+#' @param stratification_columns A character vector specifying the columns to stratify the data by.
+#'
+#' @return A tibble containing the results of the signal detection analysis stratified by the specified columns.
+#' @export
+#'
+#' @examples
+#' data <- read.csv("../data/input/input.csv")
+#' categories <- c("county", "sex", "age_group") # Replace with actual column names
+#' results <- get_signals_stratified(data, fun = get_signals_farringtonflexible, stratification_columns = categories)
+#' print(results)
+get_signals_stratified <- function(data, fun, stratification_columns) {
+  # check that all columns are present in the data
+  for (col in stratification_columns) {
+    checkmate::assert(
+      checkmate::check_choice(col, choices = names(data))
+    )
+  }
+  start_date <- min(data$date_onset)
+  end_date <- max(data$date_onset)
+
+  # Initialize an empty list to store results per category
+  category_results <- list()
+
+  # Loop through each category
+  for (category in stratification_columns) {
+    # Group the data by the current category
+    grouped_data <- data %>%
+      dplyr::group_by_at(category) %>%
+      dplyr::group_data()
+
+    # iterate over all strata and
+    for (i in 1:nrow(grouped_data)) {
+      stratum <- grouped_data[i, category][[1]]
+      sub_data <- data %>%
+        dplyr::slice(grouped_data[i, ".rows"][[1]][[1]])
+
+
+      # run selected algorithm here specifying start and end dates
+      results <- fun(sub_data, start_date, end_date)
+
+      if (is.null(results)) {
+        warning(paste0(
+          "The stratum ", category, ":", stratum,
+          " will be neglected due to lack of data."
+        ))
+      } else {
+        # add information on stratification to results
+        results <- results %>% dplyr::mutate(
+          category = category, stratum = stratum
+        )
+      }
+      # Store the results in the list
+      category_results[[stratum]] <- results
+    }
+  }
+
+  return(dplyr::bind_rows(category_results))
+}


### PR DESCRIPTION
Changes in this PR can be summarized as follows:
- Created a new wrapper function `get_signals` which allows to specify stratification columns and algorithm (currently only farrington flexible)
- Created new function `get_signals_stratified` which 
   - handles stratification
   - iteratively analyses data per stratum 
   - combines output to big dataframe
- Created new function `add_rows_missing_dates` which expands stratified data to original time horizon and fills missing year-weeks with zero cases
- Added warnings in case of lack of data
- Wrote input checks using checkmate
- Wrote roxygen comments

Would have preferred not to add new date arguments to `get_signals_farringtonflexible`. However, thorough testing in an earlier iteration revealed the need for it. Otherwise strata with few data points would have been neglected.
The available input data was very useful for many testing scenarios!