### PR TITLE
Issue #43, fixed age_group order by sorting the factoring levels

### DIFF
--- a/R/main.R
+++ b/R/main.R
@@ -68,7 +68,7 @@ shape <- sf::st_read("data/shp/NUTS_RG_03M_2021_3035.shp")
 
 # preprocess
 data <- data %>% mutate(date_onset = ifelse(is.na(date_onset) | date_onset=="", date_report, date_onset))
-data$age_group <- factor(data$age_group)
+data$age_group <- factor(data$age_group, levels = stringr::str_sort(unique(data$age_group), numeric = TRUE))
 data$sex <- factor(data$sex)
 
 # check data


### PR DESCRIPTION
Changes: 
- Added levels according to 'factor' for the variable _age_group_ in **main.R**. 

This ensures correct order, putting e.g. 100-104 at the end, rather than middle when using age_group for stratification and plotting.