### PR TITLE
Restructure signal generation

### DIFF
--- a/R/farrington_flexible.R
+++ b/R/farrington_flexible.R
@@ -1,5 +1,6 @@
 #' Get signals of surveillance's farringtonFlexible algorithm
 #' @param data_aggregated data.frame, aggregated data with case counts
+#' @param number_of_weeks integer, specifying number of weeks to generate alarms for
 #'
 #' @examples
 #' \dontrun{
@@ -9,16 +10,21 @@
 #' add_rows_missing_dates()
 #' results <- get_signals_farringtonflexible(data_aggregated)
 #' }
-get_signals_farringtonflexible <- function(data_aggregated) {
+get_signals_farringtonflexible <- function(data_aggregated,
+                                           number_of_weeks = 52) {
+
+  checkmate::assert(
+    checkmate::check_integerish(number_of_weeks)
+  )
 
   sts_cases <- convert_to_sts(data_aggregated)
 
-  num_weeks <- length(sts_cases@observed)
-  num_years <- floor((num_weeks - 26) / 52) - 1
+  num_weeks_total <- length(sts_cases@observed)
+  num_years_total <- floor((num_weeks_total - 26) / 52) - 1
 
-  if (num_years <= 0) {
+  if (num_years_total <= 0) {
     warning(paste0(
-      "Your input data/stratification only stretches over ", num_weeks,
+      "Your input data/stratification only stretches over ", num_weeks_total,
       " weeks. FarringtonFlexible needs at least a year of data to calibrate an ",
       " epidemiological baseline."
     ))
@@ -26,10 +32,10 @@ get_signals_farringtonflexible <- function(data_aggregated) {
   }
 
   control <- list(
-    range = ((num_weeks - 51):num_weeks),
+    range = ((num_weeks_total - number_of_weeks + 1):num_weeks_total),
     noPeriods = 10, populationOffset = FALSE,
     fitFun = "algo.farrington.fitGLM.flexible",
-    b = num_years, w = 3, weightsThreshold = 2.58,
+    b = num_years_total, w = 3, weightsThreshold = 2.58,
     pastWeeksNotIncluded = 26,
     pThresholdTrend = 1, trend = TRUE,
     thresholdMethod = "delta", alpha = 0.1
@@ -38,7 +44,7 @@ get_signals_farringtonflexible <- function(data_aggregated) {
   # run Farrington Flexible on data
   results <- surveillance::farringtonFlexible(sts_cases, control)
 
-  pad <- rep(NA, num_weeks - 52)
+  pad <- rep(NA, num_weeks_total - number_of_weeks)
   alarms <- c(pad, results@alarm)
   upperbound <- c(pad, results@upperbound)
   expected <- c(pad, results@control$expected)

--- a/R/tool_functions.R
+++ b/R/tool_functions.R
@@ -111,6 +111,7 @@ age_groups <- function(df, break_at = NULL) {
 #' @param date_start A date object or character of format yyyy-mm-dd specifying the start date to filter the data by. Default is NULL.
 #' @param date_end A date object or character of format yyyy-mm-dd specifying the end date to filter the data by. Default is NULL.
 #' @param date_var a character specifying the date variable name used for the aggregation. Default is "date_report".
+#' @param number_of_weeks integer, specifying number of weeks to generate alarms for.
 #' @return A tibble containing the results of the signal detection analysis
 #'   stratified by the specified columns.
 #'
@@ -129,7 +130,8 @@ get_signals_stratified <- function(data,
                                    stratification_columns,
                                    date_start = NULL,
                                    date_end = NULL,
-                                   date_var = "date_report") {
+                                   date_var = "date_report",
+                                   number_of_weeks = 52) {
   # check that all columns are present in the data
   for (col in stratification_columns) {
     checkmate::assert(
@@ -146,6 +148,14 @@ get_signals_stratified <- function(data,
     checkmate::check_null(date_end),
     checkmate::check_date(lubridate::date(date_end)),
     combine="or"
+  )
+
+  checkmate::assert(
+    checkmate::check_character(date_var, len = 1, pattern = "date")
+  )
+
+  checkmate::assert(
+    checkmate::check_integerish(number_of_weeks)
   )
 
   # Initialize an empty list to store results per category
@@ -172,7 +182,7 @@ get_signals_stratified <- function(data,
 
 
       # run selected algorithm
-      results <- fun(sub_data_agg)
+      results <- fun(sub_data_agg, number_of_weeks)
 
       if (is.null(results)) {
         warning(paste0(
@@ -206,6 +216,7 @@ get_signals_stratified <- function(data,
 #' @param date_start A date object or character of format yyyy-mm-dd specifying the start date to filter the data by. Default is NULL.
 #' @param date_end A date object or character of format yyyy-mm-dd specifying the end date to filter the data by. Default is NULL.
 #' @param date_var a character specifying the date variable name used for the aggregation. Default is "date_report".
+#' @param number_of_weeks integer, specifying number of weeks to generate alarms for.
 #' @return A tibble containing the results of the signal detection analysis.
 #' @export
 #'
@@ -221,7 +232,8 @@ get_signals <- function(data,
                         stratification = NULL,
                         date_start = NULL,
                         date_end = NULL,
-                        date_var = "date_report")  {
+                        date_var = "date_report",
+                        number_of_weeks = 52)  {
   # check that input method and stratification are correct
   checkmate::assert(
     checkmate::check_choice(method, choices = c("farrington"))
@@ -245,6 +257,10 @@ get_signals <- function(data,
     checkmate::check_character(date_var, len = 1, pattern = "date")
   )
 
+  checkmate::assert(
+    checkmate::check_integerish(number_of_weeks)
+  )
+
   if (method == "farrington") {
     fun <- get_signals_farringtonflexible
   }
@@ -257,9 +273,15 @@ get_signals <- function(data,
       aggregate_data(date_var = date_var) %>%
       add_rows_missing_dates(date_start, date_end)
 
-    results <- fun(data_agg) %>% dplyr::mutate(category = NA, stratum = NA)
+    results <- fun(data_agg, number_of_weeks) %>% dplyr::mutate(category = NA, stratum = NA)
   } else {
-    results <- get_signals_stratified(data, fun, stratification, date_start, date_end, date_var)
+    results <- get_signals_stratified(data,
+                                      fun,
+                                      stratification,
+                                      date_start,
+                                      date_end,
+                                      date_var,
+                                      number_of_weeks)
   }
 
   return(results)

--- a/man/get_signals.Rd
+++ b/man/get_signals.Rd
@@ -10,7 +10,8 @@ get_signals(
   stratification = NULL,
   date_start = NULL,
   date_end = NULL,
-  date_var = "date_report"
+  date_var = "date_report",
+  number_of_weeks = 52
 )
 }
 \arguments{
@@ -27,6 +28,8 @@ the analysis. Default is NULL.}
 \item{date_end}{A date object or character of format yyyy-mm-dd specifying the end date to filter the data by. Default is NULL.}
 
 \item{date_var}{a character specifying the date variable name used for the aggregation. Default is "date_report".}
+
+\item{number_of_weeks}{integer, specifying number of weeks to generate alarms for.}
 }
 \value{
 A tibble containing the results of the signal detection analysis.

--- a/man/get_signals_farringtonflexible.Rd
+++ b/man/get_signals_farringtonflexible.Rd
@@ -4,10 +4,12 @@
 \alias{get_signals_farringtonflexible}
 \title{Get signals of surveillance's farringtonFlexible algorithm}
 \usage{
-get_signals_farringtonflexible(data_aggregated)
+get_signals_farringtonflexible(data_aggregated, number_of_weeks = 52)
 }
 \arguments{
 \item{data_aggregated}{data.frame, aggregated data with case counts}
+
+\item{number_of_weeks}{integer, specifying number of weeks to generate alarms for}
 }
 \description{
 Get signals of surveillance's farringtonFlexible algorithm

--- a/man/get_signals_stratified.Rd
+++ b/man/get_signals_stratified.Rd
@@ -10,7 +10,8 @@ get_signals_stratified(
   stratification_columns,
   date_start = NULL,
   date_end = NULL,
-  date_var = "date_report"
+  date_var = "date_report",
+  number_of_weeks = 52
 )
 }
 \arguments{
@@ -26,6 +27,8 @@ stratify the data by.}
 \item{date_end}{A date object or character of format yyyy-mm-dd specifying the end date to filter the data by. Default is NULL.}
 
 \item{date_var}{a character specifying the date variable name used for the aggregation. Default is "date_report".}
+
+\item{number_of_weeks}{integer, specifying number of weeks to generate alarms for.}
 }
 \value{
 A tibble containing the results of the signal detection analysis


### PR DESCRIPTION
1. Move preprocessing and aggregation out of the individual outbreak detection method (i.e. farringtonflexible) to the get_signals functions
2. Add parameter number_of_weeks to the get_signals and get_signals_farringtonflexible so that we can dynamically set the number of weeks for which alarms should be generated by the algorithms