### PR TITLE
Fix bug concerning filling the stratified aggregated data with 0s in get_signals_stratified()

### DIFF
--- a/R/tool_functions.R
+++ b/R/tool_functions.R
@@ -170,10 +170,10 @@ get_signals_stratified <- function(data,
   # stratified aggregated data can be filled up with 0s until min and max date
   # of the full dataset
   if(is.null(date_start)){
-    date_start <- min(data[[date_var]])
+    date_start <- min(data[[date_var]], na.rm = TRUE)
   }
   if(is.null(date_end)){
-    date_end <- max(data[[date_var]])
+    date_end <- max(data[[date_var]], na.rm = TRUE)
   }
 
   # Loop through each category


### PR DESCRIPTION
Before the data was filtered for the stratum and then the min and maximum of this sub dataset was used when date_start and date_end where NULL as the start and end date. But the start and end dates should be those of the full dataset and the aggregated stratified data should be filled up with 0s up to then.
This PR fixes this issue by getting the min and max date before stratification.