### PR TITLE
add documentation to shiny app tabpanel modules

### DIFF
--- a/R/mod_tabpanel_help.R
+++ b/R/mod_tabpanel_help.R
@@ -2,7 +2,7 @@
 #'
 #' @description A shiny Module for a tab panel that explains how to use the shiny app.
 #'
-#' @param id,input,output,session Internal parameters for {shiny}.
+#' @param id Internal parameter for {shiny}, ensuring namespace coherency in sessions.
 #'
 #' @noRd
 #'

--- a/R/mod_tabpanel_input.R
+++ b/R/mod_tabpanel_input.R
@@ -2,7 +2,7 @@
 #'
 #' @description A shiny Module for a tab to select input parameters for analyses in the shiny app.
 #'
-#' @param id,input,output,session Internal parameters for {shiny}.
+#' @param id Internal parameter for {shiny}, ensuring namespace coherency in sessions.
 #'
 #' @noRd
 #'

--- a/R/mod_tabpanel_report.R
+++ b/R/mod_tabpanel_report.R
@@ -2,7 +2,7 @@
 #'
 #' @description A shiny Module for a tab to generate and download report of results.
 #'
-#' @param id,input,output,session Internal parameters for {shiny}.
+#' @param id Internal parameter for {shiny}, ensuring namespace coherency in sessions.
 #'
 #' @noRd
 #'

--- a/R/mod_tabpanel_signals.R
+++ b/R/mod_tabpanel_signals.R
@@ -3,7 +3,7 @@
 #' @description A shiny Module for a tab to generate and display results from
 #' signal detection methods based on parameters inputs chosen.
 #'
-#' @param id,input,output,session Internal parameters for {shiny}.
+#' @param id Internal parameter for {shiny}, ensuring namespace coherency in sessions.
 #'
 #' @noRd
 #'


### PR DESCRIPTION
This resolves and closes #74.

Added documentation to the existing modules via method generated by golem::add_module().