### PR TITLE
Feature - changes in the map visualisation

### DIFF
--- a/R/plot_regional.R
+++ b/R/plot_regional.R
@@ -60,6 +60,11 @@ plot_regional <- function(shape_with_signals,
       legend.text.align = 0
     )
 
+  # removing fill-legend if entire map is 1 zone, to avoid legend issues.
+  if (nrow(shape_with_signals) < 2) {
+    plot <- plot +
+      ggplot2::guides(fill = "none")
+  }
 
   if (interactive) {
 


### PR DESCRIPTION
Fixes #155. 

I have tried to improve the look of the map visualisation. New in this PR: 
- if a zone has an alarm, mark the entirety of the zones borders with red
- Only show number of alarms in zone, if there actually are alarms (non-interactive version)
- hovering over the zone shows the hoverlabel, not just over borders
-- There are some inconsistencies with this: when using the `SignalDetectionTool::input_example` and stratisfying by `community`, the labels were not always consistent, and in some zones showed e.g. 'No alarms' or 'At least 1 alarm', instead of the hoverinfo.
I never experienced this with the Danish data though, so may be something with NUTS_ids in the input_example.
- use a colorscheme centering around the U4S Deep Blue colour.