### PR TITLE
Feature/not show warnings in the console

### DIFF
--- a/R/app_server.R
+++ b/R/app_server.R
@@ -7,7 +7,6 @@
 app_server <- function(input, output, session) {
   # Your application server logic
   options(shiny.sanitize.errors = TRUE)
-  shinylogs::track_usage(what = "error", storage_mode = shinylogs::store_rds(path = "logs/"))
 
   mod_tabpanel_help_server("help")
 


### PR DESCRIPTION
Added `options(shiny.sanitize.errors = TRUE)` to handle the warnings/errors in the shiny app.