### PR TITLE
Plotly buttons to timeseries plot

### DIFF
--- a/R/plot_time_series.R
+++ b/R/plot_time_series.R
@@ -28,6 +28,12 @@ plot_time_series <- function(results, interactive = FALSE,
       set_status = factor(set_status, levels = c("Training data", "Test data"))
     )
 
+  if (!interactive) {
+    results <- results %>%
+      dplyr::arrange(date) %>%
+      dplyr::slice_tail(n = number_of_weeks)
+  }
+
   col.threshold <- "#2297E6"
   col.expected <- "#000000"
   col.alarm <- "#FF0000"


### PR DESCRIPTION
Resolves #206. 

With inspiration from [this article](https://plotly.com/r/time-series/#time-series-with-range-selector-buttons). I made the buttons more suited for our needs, e.g. a 'Signal detection period' button, showing only the weeks specified in input tab.
The default plot range (what is shown when loading the figure) is one year - I have not tended to the scenario where the user filters upon `date_report`.. However, the user can see the entirety of the filtered data by clicking `All time points`.

I also wanted to include #211, but appearently using either `annotate` or `geom_rect()` in cohesion with `plotly::ggplotly()` is not completely straightforward in our case. And after spending too much time on it, I decided that this will come in a seperate PR.