### PR TITLE
remove signals pad dependent section from vignette

### DIFF
--- a/vignettes/SignalDetectionTool.Rmd
+++ b/vignettes/SignalDetectionTool.Rmd
@@ -53,14 +53,6 @@ knitr::kable(input_metadata, format = "html")
 data <- preprocess_data(input_example)
 ```
 
-### Plotting the time series
-
-```{r}
-results <- get_signals(data)
-
-plot_time_series(results, interactive = TRUE)
-plot_time_series(results, number_of_weeks = 10)
-```
 
 ### Creating tables 
 


### PR DESCRIPTION
Currently cannot install packages using `build_vignette = TRUE`, so this PR removes sections which has that dependency. 