### PR TITLE
Feature/remove signals column table

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 # SignalDetectionTool 0.1.1
 
 * Several bug fixes concerning `age_groups()` function. Fixed that NA in age column is dealt with correctly in age_group, fixed that when no age column is provided in the dataset function still works and further details making the function more robust. 
+* Added EU emblem
+* Switched off warnings shown in the console
 * Updated `timeseries()` to show the blue background, signifying signal detection period, correctly, when using `facet_grid` for strata in report. 
 * Improved general readability of `timeseries` plot, when used in relation to `facet`.
 * Correcting text specifying the chosen signal detection period in Input tab.

--- a/R/results_table.R
+++ b/R/results_table.R
@@ -202,7 +202,8 @@ create_results_table <- function(data,
     data <- data %>% dplyr::filter(.data$signals == TRUE)
   }
 
-
+  data <- data %>%
+    dplyr::select(-signals)
 
   return(create_table(data, interactive))
 }
@@ -250,8 +251,7 @@ create_stratified_table <- function(signals_agg,
 
   signals_agg <- create_factor_with_unknown(signals_agg)
   signals_agg <- signals_agg %>%
-    dplyr::arrange(dplyr::desc(n_alarms)) %>%
-    dplyr::rename(signals = alarms)
+    dplyr::arrange(dplyr::desc(n_alarms))
 
   return(create_table(signals_agg, interactive))
 }


### PR DESCRIPTION
- remove signals column from the signals table. This should have been done by the PR #272 and is already in the NEWS but the column still showed up
- adding two more facts to the NEWS which were still missing