### PR TITLE
Feature/remove signals column table

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 # SignalDetectionTool 0.1.1
 
 * Several bug fixes concerning `age_groups()` function. Fixed that NA in age column is dealt with correctly in age_group, fixed that when no age column is provided in the dataset function still works and further details making the function more robust. 
+* Added EU emblem
+* Switched off warnings shown in the console
 * Updated `timeseries()` to show the blue background, signifying signal detection period, correctly, when using `facet_grid` for strata in report. 
 * Improved general readability of `timeseries` plot, when used in relation to `facet`.
 * Correcting text specifying the chosen signal detection period in Input tab.

--- a/R/results_table.R
+++ b/R/results_table.R
@@ -202,7 +202,8 @@ create_results_table <- function(data,
     data <- data %>% dplyr::filter(.data$signals == TRUE)
   }
 
-
+  data <- data %>%
+    dplyr::select(-signals)
 
   return(create_table(data, interactive))
 }
@@ -250,8 +251,7 @@ create_stratified_table <- function(signals_agg,
 
   signals_agg <- create_factor_with_unknown(signals_agg)
   signals_agg <- signals_agg %>%
-    dplyr::arrange(dplyr::desc(n_alarms)) %>%
-    dplyr::rename(signals = alarms)
+    dplyr::arrange(dplyr::desc(n_alarms))
 
   return(create_table(signals_agg, interactive))
 }

--- a/R/results_table.R
+++ b/R/results_table.R
@@ -149,16 +149,14 @@ convert_columns_integer <- function(data, columns_to_convert) {
   return(data)
 }
 
-#' Create the signal detection results table with optional filtering
+#' Create the signal detection results table showing all signals found
 #'
-#' This function creates a results table based on the input data frame. It can
-#' filter the data based on the `positive_only` parameter and converts certain
+#' This function creates a results table based on the input data frame. It converts certain
 #' columns to integers for styling purposes. This table is used to show all signal detection results for different stratifications together in one table
 #'
 #' @param data A data frame.
 #' @param interactive Logical indicating whether to create an interactive
 #'   DataTable (default is TRUE).
-#' @param positive_only Logical indicating whether to filter only those signal results where a signal was generated (default is TRUE).
 #'
 #' @return An interactive DataTable or a static gt table, depending on the value
 #'   of `interactive`.
@@ -176,16 +174,10 @@ convert_columns_integer <- function(data, columns_to_convert) {
 #' create_results_table(data)
 #' }
 create_results_table <- function(data,
-                                 interactive = TRUE,
-                                 positive_only = TRUE) {
+                                 interactive = TRUE) {
   checkmate::assert(
     checkmate::check_true(interactive),
     checkmate::check_false(interactive),
-    combine = "or"
-  )
-  checkmate::assert(
-    checkmate::check_true(positive_only),
-    checkmate::check_false(positive_only),
     combine = "or"
   )
 
@@ -195,15 +187,12 @@ create_results_table <- function(data,
   # browser()
   data <- data %>%
     dplyr::mutate(category = dplyr::if_else(is.na(category), "None", category)) %>%
-    dplyr::rename(threshold = upperbound, signals = alarms)
-
-  data <- data %>% dplyr::filter(!is.na(threshold))
-  if (positive_only) {
-    data <- data %>% dplyr::filter(.data$signals == TRUE)
-  }
+    dplyr::rename(threshold = upperbound)
 
   data <- data %>%
-    dplyr::select(-signals)
+    dplyr::filter(!is.na(threshold)) %>%
+    dplyr::filter(alarms) %>%
+    dplyr::select(-alarms)
 
   return(create_table(data, interactive))
 }

--- a/man/create_results_table.Rd
+++ b/man/create_results_table.Rd
@@ -2,25 +2,22 @@
 % Please edit documentation in R/results_table.R
 \name{create_results_table}
 \alias{create_results_table}
-\title{Create the signal detection results table with optional filtering}
+\title{Create the signal detection results table showing all signals found}
 \usage{
-create_results_table(data, interactive = TRUE, positive_only = TRUE)
+create_results_table(data, interactive = TRUE)
 }
 \arguments{
 \item{data}{A data frame.}
 
 \item{interactive}{Logical indicating whether to create an interactive
 DataTable (default is TRUE).}
-
-\item{positive_only}{Logical indicating whether to filter only those signal results where a signal was generated (default is TRUE).}
 }
 \value{
 An interactive DataTable or a static gt table, depending on the value
   of `interactive`.
 }
 \description{
-This function creates a results table based on the input data frame. It can
-filter the data based on the `positive_only` parameter and converts certain
+This function creates a results table based on the input data frame. It converts certain
 columns to integers for styling purposes. This table is used to show all signal detection results for different stratifications together in one table
 }
 \examples{


### PR DESCRIPTION
- because I also updated the develop branch with the latest changes in main there are some additional changes which were already merged into main in this PR sorry
- removed the signals column in the signal detection results table, which in my understanding should have been done in a previos PR #272 
- removed the positive_only argument from the function as we never use it and always only show the signals only.
- added some missing information from first commits after v0.1.0 to the NEWS.md