### PR TITLE
Extend filter and strata vars

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,7 @@
 * Stripping leading and trailing whitespaces from all columns of the input data in `preprocess_data()`.
 * Unified wording of "Signals"; changed all instances of "Alarms" to "Signals".
 * Fixing that the Help Tab works when installing package from binary.
+* Allow selection of all character and factor variables in the dataset, except for the variables ending with '_id', to use for filters and stratifications.
 
 # SignalDetectionTool 0.1.0
 

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -52,8 +52,16 @@ create_factor_with_unknown <- function(signals_agg) {
     signals_agg <- signals_agg %>%
       dplyr::mutate(stratum = factor(stratum, levels = do.call(category_levels, list())))
   } else {
-    signals_agg <- signals_agg %>%
-      dplyr::mutate(stratum = factor(stratum))
+    # if it is a yes no variable order it
+    if(all(signals_agg$stratum %in% yes_no_unknown_levels())){
+      signals_agg <- signals_agg %>%
+        dplyr::mutate(stratum = factor(stratum, levels = yes_no_unknown_levels()))
+    # otherwise just create a factor without special ordering
+    }else{
+      signals_agg <- signals_agg %>%
+        dplyr::mutate(stratum = factor(stratum))
+    }
+
   }
   # it is an open issue #347 on forcats that unknown levels are added even when no NA was there
   # thus write code for workaround

--- a/R/levels.R
+++ b/R/levels.R
@@ -78,6 +78,19 @@ available_algorithms <- function() {
   )
 }
 
+pretty_variable_names <- function() {
+  list(
+    age_group = "Age group",
+    subtype = "Subtype",
+    sex = "Sex",
+    hospitalization = "Hospitalization",
+    occupation = "Occupation",
+    place_of_infection = "Place of infection",
+    death = "Death",
+    vaccination = "Vaccination"
+  )
+}
+
 #' Varible names which should be checked for missing values
 check_for_missing_values <- function() {
   c("date_report")

--- a/R/mod_tabpanel_data.R
+++ b/R/mod_tabpanel_data.R
@@ -51,10 +51,10 @@ mod_tabpanel_data_ui <- function(id) {
           htmlOutput(ns("errors"))
         ), # Display errors output
         hr(), # Horizontal line for visual separation
-        h4("Columns in your dataset which were not checked for correctness and will not be used by the Signal Detection Tool"),
-        span("In this section you receive feedback about columns which are not recognised/are currently not used by this tool. These can be columns with a wrong column name which does not match the predefined names in the SOP but also additional columns you provided which are not part of the SOP. You can still continue using the app even when there are notifications in this section."),
+        h4("Columns in your dataset which were not checked for correctness"),
+        span("In this section you receive feedback about columns which are not checked by the tool. These can be columns with a wrong column name that does not match the predefined names in the SOP, as well as additional columns you provided which are not part of the SOP. You can still continue using the app even when there are notifications in this section."),
         hr(),
-        span("Please check the column names shown and correct those which should match column names defined in the SOP. The additional columns you provided can stay."),
+        span("Please check the column names shown and correct those which should match column names defined in the SOP. The additional columns you provided can stay and can be used in stratification and filters."),
         span("After you corrected the columns please upload your data again for verification."),
         hr(),
         div(

--- a/R/mod_tabpanel_input.R
+++ b/R/mod_tabpanel_input.R
@@ -178,24 +178,15 @@ mod_tabpanel_input_server <- function(id, data, errors_detected) {
     available_var_opts <- shiny::reactive({
       shiny::req(data_sub)
       shiny::req(!errors_detected())
-      available_vars <- intersect(
-        c(
-          "state",
-          "county",
-          "community",
-          "region_level1",
-          "region_level2",
-          "region_level3",
-          "subtype",
-          "age_group",
-          "sex"
-        ),
-        names(data_sub())
-      ) %>%
+      available_vars <- data_sub() %>%
+        dplyr::select(where(is.character)|where(is.factor)) %>%
+        dplyr::select(-pathogen, -dplyr::all_of(dplyr::ends_with("_id"))) %>%
+        names() %>%
         sort()
       available_vars
     })
 
+    # adding date_report to the possible filter vars
     filter_var_opts <- shiny::reactive({
       shiny::req(available_var_opts())
       shiny::req(data_sub())

--- a/R/plot_barchart.R
+++ b/R/plot_barchart.R
@@ -29,18 +29,15 @@ plot_barchart <- function(signals_agg,
     checkmate::check_false(toggle_alarms),
     combine = "or"
   )
-  # current possibilities we allow for barchart plotting
-  checkmate::assert_choice(unique(signals_agg$category), choices = c("age_group",
-                                                                     "subtype",
-                                                                     "sex"))
-  x_axis_labels <- list(age_group = "Age group",
-                        subtype = "Subtype",
-                        sex = "Sex")
 
   category <- unique(signals_agg$category)
   stopifnot(length(category) == 1)
 
-  x_label <- x_axis_labels[category]
+  if(category %in% names(pretty_variable_names())){
+    x_label <- pretty_variable_names()[category]
+  }else{
+    x_label <- category
+  }
 
   signals_agg <- create_factor_with_unknown(signals_agg)
 

--- a/R/tool_functions.R
+++ b/R/tool_functions.R
@@ -515,6 +515,7 @@ get_signals_stratified <- function(data,
     date_end <- max(data[[date_var]], na.rm = TRUE)
   }
 
+  i <- 0
   # Loop through each category
   for (category in stratification_columns) {
     if (is.factor(data[, category])) {
@@ -526,6 +527,7 @@ get_signals_stratified <- function(data,
 
     # iterate over all strata and run algorithm
     for (stratum in strata) {
+      i <- i + 1
       # when stratum is NA filter needs to be done differently otherwise the NA stratum is lost
       if (is.na(stratum)) {
         sub_data <- data %>% dplyr::filter(is.na(.data[[category]]))
@@ -568,7 +570,7 @@ get_signals_stratified <- function(data,
         )
       }
       # Store the results in the list
-      category_results[[stratum]] <- results
+      category_results[[i]] <- results
     }
   }
 


### PR DESCRIPTION
resolves #268 

- user can now use all available character and factor variables for stratification and filtering except for the _id variables
-  check for the outbreak_status column values which we have predefined for the algorithm evaluation will still be added when working on #286

- the "only" danger is that now the user has much more possibiities for stratifications which might not even make sense so it is more in his/her responsibility to understand thus there might be more explanations/training needed