### PR TITLE
Timeseries plot and signaltab UI 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,6 +28,7 @@ Imports:
     golem (>= 0.4.1),
     grDevices,
     gt (>= 0.9.0),
+    htmlwidgets (>= 1.5.3),
     ISOweek (>= 0.6.2),
     lubridate (>= 1.9.0),
     magrittr (>= 2.0.3),

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,8 +3,11 @@
 * Several bug fixes concerning `age_groups()` function. Fixed that NA in age column is dealt with correctly in age_group, fixed that when no age column is provided in the dataset function still works and further details making the function more robust. 
 * Added EU emblem
 * Switched off warnings shown in the console
-* Updated `timeseries()` to show the blue background, signifying signal detection period, correctly, when using `facet_grid` for strata in report. 
-* Improved general readability of `timeseries` plot, when used in relation to `facet`.
+* Updates and bug fixes to `plot_time_series()` 
+  - show the blue background, signifying signal detection period, correctly, when using `facet_grid` for strata in report. 
+  - Improved general readability of `timeseries` plot, when used in relation to `facet`.
+  - Improved positioning of bars for case numbers and blue background coverage.
+  - Interactive plot in app and HTML report now adapts y-range according to x-zoom and the x-axis do not anymore extend into the future.
 * Correcting text specifying the chosen signal detection period in Input tab.
 * Changes appearance of all tables, removes rownames and alarm column, more concise grouping
 * Adds filter and export functionality to all tables

--- a/R/mod_tabpanel_signals.R
+++ b/R/mod_tabpanel_signals.R
@@ -58,7 +58,7 @@ mod_tabpanel_signals_server <- function(
               shiny::div(
                 class = "value-box blue",
                 shiny::div(class = "title", "Outbreak detection algorithm"),
-                shiny::div(class = "value", get_name_by_value(method(),available_algorithms()))
+                shiny::div(class = "value", get_name_by_value(method(), available_algorithms()))
               )
             ),
             column(
@@ -69,50 +69,29 @@ mod_tabpanel_signals_server <- function(
                 shiny::div(class = "value", number_of_weeks())
               )
             ),
-            # Red box if signals were found
-            if (sum(signals_agg()$n_alarms) > 0) {
+           # Box of total alarms
+            # Red box if alarms were found, green if no alarms
               column(
                 width = 2,
                 shiny::div(
-                  class = "value-box red",
-                  shiny::div(class = "title", "Number of signals"),
+                  class = ifelse(sum(signals_agg()$n_alarms) > 0,
+                                 "value-box red", "value-box green"),
+                  shiny::div(class = "title", "Number of alarms"),
                   shiny::div(class = "value", shiny::textOutput(ns("n_alarms")))
                 )
-                # Green box if no signals were found
-              )
-            } else {
-              column(
-                width = 2,
-                shiny::div(
-                  class = "value-box green",
-                  shiny::div(class = "title", "Number of signals"),
-                  shiny::div(class = "value", shiny::textOutput(ns("n_alarms")))
-                )
-              )
-            },
-            # Box of signals by stratum
+              ),
+            # Box of alarms by stratum
             if (!"None" %in% strat_vars()) {
-              # Red box if signals were found
-              if (sum(signals_agg()$n_alarms) > 0) {
-                column(
-                  width = 4,
-                  shiny::div(
-                    class = "value-box red",
-                    shiny::div(class = "title", "Number of signals by stratum"),
-                    shiny::div(class = "value", shiny::htmlOutput(ns("signals_stratum")))
-                  )
+              # Red box if alarms were found, green if no alarms
+              column(
+                width = 4,
+                shiny::div(
+                 class = ifelse(sum(signals_agg()$n_alarms) > 0,
+                                 "value-box red", "value-box green"),
+                  shiny::div(class = "title", "Number of alarms by stratum"),
+                  shiny::div(class = "value", shiny::htmlOutput(ns("signals_stratum")))
                 )
-                # Green box if no signals were found
-              } else {
-                column(
-                  width = 4,
-                  shiny::div(
-                    class = "value-box green",
-                    shiny::div(class = "title", "Number of signals by stratum"),
-                    shiny::div(class = "value", shiny::htmlOutput(ns("signals_stratum")))
-                  )
-                )
-              }
+              )
             }
           ),
           shiny::uiOutput(ns("alarm_button")),

--- a/R/mod_tabpanel_signals.R
+++ b/R/mod_tabpanel_signals.R
@@ -69,26 +69,26 @@ mod_tabpanel_signals_server <- function(
                 shiny::div(class = "value", number_of_weeks())
               )
             ),
-           # Box of total alarms
-            # Red box if alarms were found, green if no alarms
+           # Box of signals in total
+            # Red box if signals were found, green if no signals
               column(
                 width = 2,
                 shiny::div(
                   class = ifelse(sum(signals_agg()$n_alarms) > 0,
                                  "value-box red", "value-box green"),
-                  shiny::div(class = "title", "Number of alarms"),
+                  shiny::div(class = "title", "Number of signals"),
                   shiny::div(class = "value", shiny::textOutput(ns("n_alarms")))
                 )
               ),
-            # Box of alarms by stratum
+            # Box of signals by stratum
             if (!"None" %in% strat_vars()) {
-              # Red box if alarms were found, green if no alarms
+              # Red box if signals were found, green if no signals
               column(
                 width = 4,
                 shiny::div(
                  class = ifelse(sum(signals_agg()$n_alarms) > 0,
                                  "value-box red", "value-box green"),
-                  shiny::div(class = "title", "Number of alarms by stratum"),
+                  shiny::div(class = "title", "Number of signals by stratum"),
                   shiny::div(class = "value", shiny::htmlOutput(ns("signals_stratum")))
                 )
               )

--- a/R/mod_tabpanel_signals.R
+++ b/R/mod_tabpanel_signals.R
@@ -41,7 +41,7 @@ mod_tabpanel_signals_server <- function(
     ns <- session$ns
 
     # UI-portion of the tab below!
-    # ensuring that content is onlyu shown if data check returns no errors
+    # ensuring that content is only shown if data check returns no errors
     output$signals_tab_ui <- shiny::renderUI({
       if (errors_detected() == TRUE) {
         return(datacheck_error_message)
@@ -139,7 +139,7 @@ mod_tabpanel_signals_server <- function(
       shiny::req(!(length(unique(strat_vars())) == 1 & strat_vars() == "None")) # only show the filter button when strata were selected
       shiny::selectInput(
         inputId = ns("ts_filter_var"),
-        label = "Chose stratum",
+        label = "Choose stratum",
         choices = c(strat_vars(), "None"),
         selected = "None"
       )

--- a/R/plot_time_series.R
+++ b/R/plot_time_series.R
@@ -1,4 +1,4 @@
-#' Plot time-series based on the results of Farrington Flexible
+#' Plot time-series based on the results of a signal detection algorithm, being alarms, threshold and expectation
 #'
 #' Static plots (default) are only based on the dates of the latest
 #' `number_of_weeks` weeks. Interactive plots are based on all data, but zoom in
@@ -124,7 +124,7 @@ plot_time_series <- function(results, interactive = FALSE,
       )
   }
 
-  # adding alarm points
+  # adding signal points
   plt <- plt +
     ggplot2::geom_point(
       data = dplyr::filter(results, alarms == TRUE),

--- a/R/plot_time_series.R
+++ b/R/plot_time_series.R
@@ -203,7 +203,6 @@ plot_time_series <- function(results, interactive = FALSE,
           ),
           rangeselector = list(
             buttons = list(
-              list(count=ndays_sdp, label="Signal detection period", step="day", stepmode="backward"),
               list(count=1, label="1 month", step="month", stepmode="backward"),
               list(count=6, label="6 months", step="month", stepmode="backward"),
               list(count=1, label="1 year", step="year", stepmode="backward"),

--- a/R/plot_time_series.R
+++ b/R/plot_time_series.R
@@ -197,6 +197,8 @@ plot_time_series <- function(results, interactive = FALSE,
           rangeslider = list(
             range = range_dates_all,
             visible = TRUE,
+            yaxis = list(range = c(0, ymax_data),
+                         rangemode = "fixed"), # so we always can see the big picture in the rangeslider plot
             thickness = 0.10
           ),
           rangeselector = list(

--- a/R/plot_time_series.R
+++ b/R/plot_time_series.R
@@ -1,11 +1,11 @@
 #' Plot time-series based on the results of Farrington Flexible
 #'
 #' Static plots (default) are only based on the dates of the latest
-#' `number_of_weeks` weeks. Interactive plots are based on all data, but default
-#' zoom on `number_of_weeks` weeks.
+#' `number_of_weeks` weeks. Interactive plots are based on all data, but zoom in
+#' by default on the latest `number_of_weeks` weeks.
 #'
 #' @param results data returned by the get_signals_farringtonflexible()
-#' @param interactive if TRUE, interactive plot is returned; FALSE (default), static plot.
+#' @param interactive logical, if TRUE, interactive plot is returned; default, static plot.
 #' @param number_of_weeks number of weeks to be covered in the plot
 #'
 #' @return either a gg or plotly object
@@ -244,16 +244,13 @@ plot_time_series <- function(results, interactive = FALSE,
             el.on('plotly_relayout', function(eventdata) {
               var x_range = eventdata['xaxis.range'];
               if(x_range) {
-                console.log(`x_range: ${x_range}`);
                 var x_min = x_range[0];
                 var x_max = x_range[1];
                 var max_y_in_view =
-                  Math.max.apply(null, data.filter(function(d, i) {
-                    if(i == 1) {console.log({date:d.date, x_min:x_min, truth:d.date >= x_min});}
-                    return d.date >= x_min && d.date <= x_max;
+                  Math.max.apply(null, data.filter(function(d) {
+                      return d.date >= x_min && d.date <= x_max;
                     }).map(d => d.ymax)
                   );
-                console.log(`max_y_in_view: ${max_y_in_view}`);
                 Plotly.relayout(el, {'yaxis.range': [0, max_y_in_view]});
               }
             });

--- a/R/plot_time_series.R
+++ b/R/plot_time_series.R
@@ -62,6 +62,7 @@ plot_time_series <- function(results, interactive = FALSE,
 
     10^floor(log10(x)) * levels[[which(x <= 10^floor(log10(x)) * levels)[[1]]]]
   }
+  ymax_data <- max(c(results$cases, results$upperbound), na.rm = TRUE)
 
   col.threshold <- "#2297E6"
   col.expected <- "#000000"
@@ -94,9 +95,7 @@ plot_time_series <- function(results, interactive = FALSE,
                        ggplot2::aes(x = NULL, y = NULL,
                                     xmin = start, xmax = end,
                                     fill = paste0("bg_", set_status)),
-                       ymin = 0, ymax = plyr::round_any(x = max(results$cases, na.rm = TRUE),
-                                                        f = ceiling,
-                                                        accuracy = custom_round_up(max(results$cases, na.rm = TRUE))),
+                       ymin = 0, ymax = custom_round_up(ymax_data),
                        colour = "white", linewidth = 0.5, alpha = 0.2) +
     ggplot2::geom_col(
       ggplot2::aes(x = date + half_week, # center bars around mid-week

--- a/inst/report/SignalDetectionReport_strata.Rmd
+++ b/inst/report/SignalDetectionReport_strata.Rmd
@@ -43,7 +43,7 @@ txt <- NULL
 #| fig.dim = c(8, p_height),
 #| fig.fullwidth=TRUE
 plot_time_series(df,
-                 number_of_weeks = 52 * dplyr::n_distinct(df$stratum),
+                 number_of_weeks = 52,
                  interactive = FALSE) + 
   ggplot2::facet_wrap(~stratum, ncol = 2, scales = "free_y") +
   ggplot2::scale_x_date(

--- a/man/plot_time_series.Rd
+++ b/man/plot_time_series.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/plot_time_series.R
 \name{plot_time_series}
 \alias{plot_time_series}
-\title{Plot time-series based on the results of Farrington Flexible}
+\title{Plot time-series based on the results of a signal detection algorithm, being alarms, threshold and expectation}
 \usage{
 plot_time_series(results, interactive = FALSE, number_of_weeks = 52)
 }

--- a/man/plot_time_series.Rd
+++ b/man/plot_time_series.Rd
@@ -9,7 +9,7 @@ plot_time_series(results, interactive = FALSE, number_of_weeks = 52)
 \arguments{
 \item{results}{data returned by the get_signals_farringtonflexible()}
 
-\item{interactive}{if TRUE, interactive plot is returned}
+\item{interactive}{logical, if TRUE, interactive plot is returned; default, static plot.}
 
 \item{number_of_weeks}{number of weeks to be covered in the plot}
 }
@@ -17,7 +17,9 @@ plot_time_series(results, interactive = FALSE, number_of_weeks = 52)
 either a gg or plotly object
 }
 \description{
-Plot time-series based on the results of Farrington Flexible
+Static plots (default) are only based on the dates of the latest
+`number_of_weeks` weeks. Interactive plots are based on all data, but zoom in
+by default on the latest `number_of_weeks` weeks.
 }
 \examples{
 \dontrun{


### PR DESCRIPTION
### Resolves #231, #277 and #279.

Most of this PR focuses on fixing various issues related to the time series plot, plus some minor stuff such as spelling errors and code refactoring in the module-code for the signal tab.

The time series barplot now has bars centered mid-week such that the threshold line no longer appears to step up/down in the middle of the week. The blue background of the signal detection period has been expanded to cover the bars accordingly.

Various bugs have been fixed by being more explicit about plot ranges. Some JavaScript is injected to solve plotly-quirks with the interactive plot when zooming in on specific date ranges.

**Note:** htmlwidgets is a new dependency.

### Discussion points
#231: The plotly range selector buttons in the top-left corner of the interactive plot only adjusts on the start date of the displayed date-interval - the end date is left as-is - which means, that when first panning the slider and then pressing a range selection button, e.g. `6 months` as in the figure below, the end date displayed in the zoomed plot is no longer the last date in data. 
*Should our design intention be to always get the right interval end point to the most current date when pressing one of the range selector buttons?* 
That might not be possible with plotly as-is, but is likely possible by extending the JavaScript in this PR.
![image](https://github.com/United4Surveillance/signal-detection-tool/assets/144324550/0056bddb-f1e0-4f9e-b5c1-3302a84f8cca)

#277: Two remaining issues:
* The plotly dates on the x-axis are still Sundays (hard to change how plotly decides).
* The hover dates are still Mondays (from the results object in plot_time_series()) -
   *Should we change it to display `<year>-W<week>`*?

#### Adaptive y-axis
A local `ymax` for each week is now calculated taking into account the max of the case numbers, threshold line or signal marker. The overall `ymax` is used for clipping the y-range on the plotly-figure and is set to 1,2,5 * b (b a power of 10). 
As it is now the, sliderange inset at the bottom of the figure is using the same ymax which may cause the threshold line to not be visible on the inset. See example here:
![image](https://github.com/United4Surveillance/signal-detection-tool/assets/144324550/af994cdb-7837-4df4-a130-e7876fd026e2)
![image](https://github.com/United4Surveillance/signal-detection-tool/assets/144324550/adfffebe-fc54-4c6c-b38d-0ab4c1810770)

*- Should we opt for the signal threshold line is always visible on the sliderange inset?*
If always visible it is easier to relate the zoomed date range earlier in the period to the calculated threshold levels later on, but it might be more difficult to discern smalller case numbers.
