### PR TITLE
removing restrictions for the stratified timeseries plot in the report

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,6 +24,7 @@ Imports:
     config (>= 0.3.2),
     dplyr (>= 1.1.4),
     DT (>= 0.26),
+    ggforce (>= 0.4.2), 
     ggplot2 (>= 3.4.4),
     golem (>= 0.4.1),
     grDevices,

--- a/inst/report/SignalDetectionReport_strata.Rmd
+++ b/inst/report/SignalDetectionReport_strata.Rmd
@@ -31,18 +31,31 @@ decider_barplot_map_table(signals_agg,
 df <- signal_results %>% 
   dplyr::filter(category %in% strat)
 
-p_height <- ceiling(dplyr::n_distinct(df$stratum)/2) * 2
+number_stratum <- dplyr::n_distinct(df$stratum)
+
+if (number_stratum <= 10) {
+  p_height <- ceiling(dplyr::n_distinct(df$stratum)/2) * 2
+} else {
+  p_height <- 12 
+}
+
+pages <- ceiling(number_stratum/12)
+format <- knitr::opts_knit$get("rmarkdown.pandoc.to")
+eval_paginate <- !grepl("html", format, ignore.case = TRUE)
+
 txt <- NULL
+ 
 ```
 
 
 ```{r}
+#| eval= !eval_paginate,
 #| fig.cap=paste0("Number of ", params$disease, " cases by week and signals stratified by ", strat_text, ", ", params$country),
-#| fig.dim = c(8, p_height),
+#| fig.dim = c(8, number_stratum),
 #| fig.fullwidth=TRUE
 plot_time_series(df,
                  number_of_weeks = 52,
-                 interactive = FALSE) + 
+                 interactive = FALSE) +
   ggplot2::facet_wrap(~stratum, ncol = 2, scales = "free_y") +
   ggplot2::scale_x_date(
         date_breaks = "2 months", date_labels = "%Y-%m-%d",
@@ -51,6 +64,31 @@ plot_time_series(df,
 
 ```
 
+```{r, results='asis'}
+#| eval= eval_paginate,
+#| fig.cap=paste0("Number of ", params$disease, " cases by week and signals stratified by ", strat_text, ", ", params$country),
+#| fig.dim = c(8, p_height),
+#| fig.fullwidth=TRUE
+
+for (i in seq_len(pages)) {
+  p <- plot_time_series(df,
+                 number_of_weeks = 52,
+                 interactive = FALSE) + 
+  ggforce::facet_wrap_paginate(~stratum, 
+                               ncol = 2, 
+                               nrow = 6, 
+                               scales = "free_y",
+                               page = i) +
+  ggplot2::scale_x_date(
+        date_breaks = "2 months", date_labels = "%Y-%m-%d",
+        expand = c(0, 0)
+      )
+  
+  print(p)
+}
+
+
+```
 
 
 `r if (params$tables) "### Signal Detection Table"`

--- a/inst/report/SignalDetectionReport_strata.Rmd
+++ b/inst/report/SignalDetectionReport_strata.Rmd
@@ -31,14 +31,12 @@ decider_barplot_map_table(signals_agg,
 df <- signal_results %>% 
   dplyr::filter(category %in% strat)
 
-eval_ts_facet <- ((dplyr::n_distinct(df$stratum) <= 12))
 p_height <- ceiling(dplyr::n_distinct(df$stratum)/2) * 2
 txt <- NULL
 ```
 
 
 ```{r}
-#| eval = eval_ts_facet,
 #| fig.cap=paste0("Number of ", params$disease, " cases by week and signals stratified by ", strat_text, ", ", params$country),
 #| fig.dim = c(8, p_height),
 #| fig.fullwidth=TRUE


### PR DESCRIPTION
@alchalu
Why did you decide to introduce the limit for the facet_wrap in the report? :) I understand that with a lot of strata it might be overwhelming but currently looks ok. I was confused that the stratified figures for the age groups were not shown anymore in the report, that is how I found out about it.

What do you think about removing this statement like done in this PR or increasing the limit to 25 for now?
If we decide to not show the stratified timeseries because too many strata we should maybe

- only show those strata where a signal was generated
- inform the user about this
Thanks :)