### PR TITLE
Adding legend-modification to the plot_regional.R script

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+* Fixing bug so the legend in the interactive version of the plot_regional function only shows the border-color
+
 # SignalDetectionTool 0.3.0
 
 * Losening restriction on which region information can be used for creating maps. Now all region variables including region_level variables can be used which is necessary for users who want to use their own shapefiles for their defined regions.

--- a/R/plot_regional.R
+++ b/R/plot_regional.R
@@ -138,6 +138,16 @@ plot_regional <- function(shape_with_signals,
         "zoom2d",
         "toggleSpikelines"
       ))
+    # modifying the interactive plot legend
+    # Finding nr of trace with a showlegend = T
+    legends_2_copy <- which(sapply(plot$x$data, function(l){l$showlegend == TRUE}))
+    # Copy trace and show only bordercolor
+    for(idx in legends_2_copy){
+      n_list <- length(plot$x$data)
+      plot$x$data[[n_list+1]] <- plot$x$data[[idx]]
+      plot$x$data[[n_list+1]]$fillcolor <- "transparent"
+      plot$x$data[[idx]]$showlegend <- FALSE
+    }
   }
 
   plot


### PR DESCRIPTION
Regarding bug #202 

I could not change the legend-shape, but I have removed the confusing second color-line in the plot.
The new plot should just show a single color-line in the legend (see attached)

![image](https://github.com/user-attachments/assets/a9cf005a-12c4-462e-90d6-78ce5f1ee041)
