### PR TITLE
Add ability to investiage line list of signals

### DIFF
--- a/R/app_server.R
+++ b/R/app_server.R
@@ -39,4 +39,16 @@ app_server <- function(input, output, session) {
     signals_agg = signals_output$signals_agg,
     intervention_date = datinput$intervention_date
   )
+
+  mod_tabpanel_investigation_server("investigation",
+    filtered_data = datinput$filtered_data,
+    errors_detected = data_load_check_result$errors_detected,
+    number_of_weeks = datinput$n_weeks,
+    number_of_weeks_input_valid = datinput$weeks_input_valid,
+    strat_vars = datinput$strat_vars,
+    method = datinput$method,
+    no_algorithm_possible = datinput$no_algorithm_possible,
+    intervention_date = datinput$intervention_date,
+    signals_padded = signals_output$signals_padded
+    )
 }

--- a/R/app_ui.R
+++ b/R/app_ui.R
@@ -33,6 +33,7 @@ app_ui <- function(request) {
             mod_tabpanel_input_ui("input"),
             mod_tabpanel_signals_ui("signals"),
             mod_tabpanel_report_ui("report"),
+            mod_tabpanel_investigation_ui("investigation"),
             selected = "Data"
           )
         )

--- a/R/mod_tabpanel_investigation.R
+++ b/R/mod_tabpanel_investigation.R
@@ -1,0 +1,169 @@
+#' tabpanel "Data Investigation" UI Function
+#'
+#' @description A shiny Module for a tab to display line list cases related to a
+#' detected signal based on parameters inputs chosen. Ability to download data
+#' to file.
+#'
+#' @param id Internal parameter for {shiny}, ensuring namespace coherency in sessions.
+#'
+#' @noRd
+#'
+#' @importFrom shiny NS tagList
+mod_tabpanel_investigation_ui <- function(id) {
+  ns <- shiny::NS(id)
+  shiny::tabPanel(
+    title = "Signal Investigation",
+    icon = shiny::icon("magnifying-glass"),
+    shinybusy::add_busy_spinner(
+      spin = "fading-circle",
+      color = "#304794",
+      position = "full-page",
+      height = "100px",
+      width = "100px"
+    ),
+    shiny::uiOutput(ns("signal_investigation_tab_ui"))
+  )
+}
+
+
+#' tabpanel "Data investigation" Server Functions
+#'
+#' @noRd
+mod_tabpanel_investigation_server <- function(
+    id,
+    filtered_data,
+    errors_detected,
+    number_of_weeks,
+    number_of_weeks_input_valid,
+    strat_vars,
+    method,
+    no_algorithm_possible,
+    intervention_date,
+    signals_padded) {
+  shiny::moduleServer(id, function(input, output, session) {
+    ns <- session$ns
+
+    # UI-portion of the tab below!
+    # ensuring that content is only shown if data check returns no errors
+    output$signal_investigation_tab_ui <- shiny::renderUI({
+      if (errors_detected() == TRUE) {
+        return(datacheck_error_message)
+      } else if (!number_of_weeks_input_valid()) {
+        return(nweeks_error_message)
+      } else if (no_algorithm_possible() == TRUE) {
+        return(algorithm_error_message)
+      } else {
+        return(shiny::tagList(
+          shiny::fluidRow(
+            shiny::column(12,
+                          shiny::wellPanel(
+                          shiny::h3("Investigate signals", style = "color:#304794"),
+                          shiny::span("Click into the table to select the signals you want to investigate."),
+                          shiny::hr(),
+                          shiny::span(paste0("Detected signals using method '",
+                                             get_name_by_value(method(), available_algorithms()), "':"),
+                                      style = "font-size:120%;font-weight: bold"),
+                          shiny::br(),
+                          DT::DTOutput(ns("show_signals_padded"))
+                          )
+            )
+          ),
+          shiny::br(),
+          shiny::h3("Line list of selected signals", style = "color:#304794"),
+          shiny::span("Click any of the buttons below to export the line list in your desired format."),
+          DT::DTOutput(ns("linelist"))
+        ))
+      }
+    })
+
+
+    true_signals <- shiny::reactive({
+      shiny::req(signals_padded)
+      signals_padded() %>% dplyr::filter(alarms == TRUE) %>%
+        dplyr::select(!tidyselect::starts_with("expect"))
+    })
+
+    # output padded signal data in table
+    output$show_signals_padded <- DT::renderDataTable({
+      req(true_signals)
+      DT::datatable(
+        true_signals(),
+        options = list(
+          scrollX = TRUE
+        )
+      )
+    })
+
+    # Display selected rows
+    output$selected_rows <- renderPrint({
+      selected_rows <- input$show_signals_padded_rows_selected
+      if (length(selected_rows) == 0) {
+        "No rows selected"
+      } else {
+        selected_rows
+      }
+    })
+
+    # display line lists of selected signals
+    output$linelist <- DT::renderDataTable({
+      req(filtered_data)
+      req(true_signals)
+      # check if any signals are selected for investigation
+      req(!is.na(input$show_signals_padded_rows_selected))
+      # selected rows by user in UI
+      selected_signal_ids <- sort(input$show_signals_padded_rows_selected)
+
+      filter_rows <- function(df1_row, df2) {
+        # extract year and week out of df1
+        year <- df1_row$year
+        week <- df1_row$week
+        category <- df1_row$category
+        stratum <- df1_row$stratum
+
+        # determine start and end time of detection period
+        start_date <- ISOweek::ISOweek2date(paste0(year, "-W", sprintf("%02d", week), "-1"))
+        end_date <- start_date + lubridate::days(6)
+
+        # Dynamic filtering
+        filtered_df <- df2 %>%
+          dplyr::filter(
+            date_report >= start_date & date_report <= end_date # Filter für das Datum
+          )
+
+        # further filtering if stratification was applied
+        if (!is.na(category) && !is.na(stratum)) {
+          filtered_df <- filtered_df %>%
+            dplyr::filter(!!sym(category) == stratum)
+        }
+
+        return(filtered_df)
+      }
+
+      # Filter rows for each signal ID
+      cases <- purrr::map_dfr(selected_signal_ids, function(signal_id) {
+        # Extract the corresponding row from true_signals()
+        signal_row <- true_signals() %>% dplyr::slice(signal_id)
+
+        # Apply the filtering function
+        filtered_cases <- filter_rows(signal_row, filtered_data())
+
+        # Add signal_id column
+        filtered_cases <- filtered_cases %>%
+          dplyr::mutate(signal_id = signal_id, .before = 1)
+
+        return(filtered_cases)
+      })
+
+      DT::datatable(
+        cases,
+        extensions = 'Buttons',
+        options = list(
+          dom = 'Bfrtip',
+          buttons = c('copy', 'csv', 'excel', 'pdf', 'print'),
+          scrollX = TRUE
+        )
+      )
+    })
+
+  })
+}


### PR DESCRIPTION
PR relates to [issue 269 ](https://github.com/United4Surveillance/signal-detection-tool/issues/269)

Added a new tab called 'Signal investigation' with following features:

- table of detected signals is shown
- user can select signals to investigate, by clicking into the table (multiple selection is possible)
- a line list of all cases related to the selected signals is shown below
- the user can export the line list in various formats

The solution makes use of as much functionality of the DT package as possible.