### PR TITLE
description of minimal requirements of shapefile variables in metadata

### DIFF
--- a/dev/data/input/shapefile_metadata.md
+++ b/dev/data/input/shapefile_metadata.md
@@ -1,0 +1,5 @@
+| Variable  | Mandatory | Type                    | Description                                                                                                                                                                    |
+|-----------|-----------|-------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| NUTS_ID   | YES       | character or numeric    | The type must be the same as the type used for the \_id variables in the cases linelist as the shapefile is joined to the aggregated cases on the \_id variables and NUTS_ID.  |
+| NUTS_NAME | YES       | character               | This is used for displaying region names in the map.                                                                                                                           |
+| geometry  | YES       | sfc_MULTIPOLYGON or sfc | This is the geometry of the regions.                                                                                                                                           |


### PR DESCRIPTION
This adds an .md file describing the variables needed in a shapefile when users want to use an external shapefile for example. 
Fixes #360 
Questions:

- currently the NUTS_NAME is used to display the names in the map plot. We do not necessarily need the NUTS_NAME we could also use the name of the region provided in the linelist of cases. Maybe it is more reliable to use the NUTS_NAME as the name of the region could be missing in the data but actually I think we catch this and give feedback to the user. Should we change this to rather use the names of the region provided within the linelist?
- I did not create a internal dataset like the input_metadata dataset because I thought this is not necessary. We can just guide the user in the gist or readme to this description. What do you think?
