### PR TITLE
adding github action for the github page when merge to main

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -14,3 +14,6 @@ $run_dev.*
 ^Meta$
 ^README\.Rmd$
 ^\.github$
+^_pkgdown\.yml$
+^docs$
+^pkgdown$

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -1,0 +1,49 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+name: pkgdown.yaml
+
+permissions: read-all
+
+jobs:
+  pkgdown:
+    runs-on: ubuntu-latest
+    # Only restrict concurrency for non-PR jobs
+    concurrency:
+      group: pkgdown-${{ github.event_name != 'pull_request' || github.run_id }}
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::pkgdown, local::.
+          needs: website
+
+      - name: Build site
+        run: pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)
+        shell: Rscript {0}
+
+      - name: Deploy to GitHub pages 🚀
+        if: github.event_name != 'pull_request'
+        uses: JamesIves/github-pages-deploy-action@v4.5.0
+        with:
+          clean: false
+          branch: gh-pages
+          folder: docs

--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,4 @@ rsconnect/
 inst/doc
 /doc/
 /Meta/
+docs

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -67,3 +67,4 @@ Encoding: UTF-8
 Language: en-US
 LazyData: true
 RoxygenNote: 7.3.2
+URL: https://united4surveillance.github.io/signal-detection-tool/

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,0 +1,4 @@
+url: https://united4surveillance.github.io/signal-detection-tool/
+template:
+  bootstrap: 5
+


### PR DESCRIPTION


I added a Github action such that each time there is a merge into main (new release) the gh-pages branch is updated and the corresponding github page is updated.
https://united4surveillance.github.io/signal-detection-tool/articles/SignalDetectionTool.html
This github action is just copy pasted from here:
https://github.com/r-lib/actions/blob/v2/examples/pkgdown.yaml

I think we can't really test this PR and I also directly want to merge it into main. This will be tested as soon as there is a new release on main.

The corresponding Github Page will still receive some adaptation content wise.
