### PR TITLE
Fix edge case in plot_regional

### DIFF
--- a/R/plot_regional.R
+++ b/R/plot_regional.R
@@ -28,7 +28,8 @@ plot_regional <- function(shape_with_signals,
     dplyr::mutate(
       n_alarms_label = dplyr::if_else(n_alarms > 0, n_alarms, NA),
       any_alarms = dplyr::if_else(any_alarms, "At least 1 signal", "No signals",
-                                  missing = "No signals"),
+        missing = "No signals"
+      ),
       any_alarms = factor(any_alarms, levels = c("No signals", "At least 1 signal")) # level ordering determines render ordering: black < red
     )
 


### PR DESCRIPTION
This PR fixes an error that can occur in some edge cases in the calculation and plotting of centroids of polygons for a map.
The error would occur for instance when there are signals detected in both German states Schleswig-Holstein and Mecklenburg-Vorpommern. The root cause of the issue must lie in the polygons of the shapefile, possibly because of irregular coast lines. 
The introduced changes should make the code more robust in the sense that:
- the shape dataframe is filtered and only used for plotting if valid polygons remain
- the centroid caclulation is done on the largest polygon, neglecting smaller separate polygons like islands
- the centroid coordinates are explicitly converted to points and plotted by their x and y coordinates.