### PR TITLE
add info in the report tab that HTML report is now a zip file

### DIFF
--- a/R/mod_tabpanel_report.R
+++ b/R/mod_tabpanel_report.R
@@ -80,7 +80,6 @@ mod_tabpanel_report_server <- function(id,
                   value = TRUE
                 )
               ),
-
               shiny::conditionalPanel(
                 condition = sprintf("input['%s'] == 'HTML'", NS(id, "format")),
                 shiny::div(
@@ -89,9 +88,7 @@ mod_tabpanel_report_server <- function(id,
                   "The HTML report is downloaded as a ZIP File. Please extract (unzip) this file before opening the report. If you open the HTML file directly inside the ZIP archive, the report will not display correctly."
                 )
               ),
-
               shiny::downloadButton(NS(id, "downloadReport"), "Create Report")
-
             ),
             bslib::card(
               shiny::textOutput(NS(id, "report_text"))


### PR DESCRIPTION
Users could be confused by the change to .zip and the report is not working if not unzipped