### PR TITLE
only changing documentation for post processing parameter

### DIFF
--- a/R/run_report.R
+++ b/R/run_report.R
@@ -36,7 +36,7 @@
 #' @param intervention_date A date object or character of format yyyy-mm-dd or NULL specifying the date for the intervention. This can be used for interrupted timeseries analysis. It only works with the following methods: "Mean", "Timetrend", "Harmonic", "Harmonic with timetrend", "Step harmonic", "Step harmonic with timetrend". Default is NULL which indicates that no intervention is done.
 #' @param custom_logo A character string with a path to a png or svg logo, to replace the default United4Surveillance logo. Only used when `report_format` is `"HTML"`.
 #' @param custom_theme A bslib::bs_theme() to replace the default United4Surveillance theme. This is mainly used to change colors. See the bslib documentation for all parameters. Use version = "3" to keep the navbar intact. Only used when `report_format` is `"HTML"`.
-#' @param min_cases_signals integer, minimum number of cases a signal must have. All signals with case counts smaller than this will be filtered in a post-processing step
+#' @param min_cases_signals integer, minimum number of cases a signal must have. All signals with case counts smaller than this will be filtered in a post-processing step. This parameter is only applied when precomputed signals_agg and signals_padded are not given. If you want to post-process your precomputed signals you need to do that before generating the report.
 #' @param title NULL or a character string. Specifies the title of the report that is to be created
 #'
 #' @return the compiled document is written into the output file, and the path of the output file is returned; see \link[rmarkdown]{render}

--- a/man/run_report.Rd
+++ b/man/run_report.Rd
@@ -65,7 +65,7 @@ If not `NULL`, the provided `signals_agg` is used directly and signals are not r
 
 \item{custom_theme}{A bslib::bs_theme() to replace the default United4Surveillance theme. This is mainly used to change colors. See the bslib documentation for all parameters. Use version = "3" to keep the navbar intact. Only used when `report_format` is `"HTML"`.}
 
-\item{min_cases_signals}{integer, minimum number of cases a signal must have. All signals with case counts smaller than this will be filtered in a post-processing step}
+\item{min_cases_signals}{integer, minimum number of cases a signal must have. All signals with case counts smaller than this will be filtered in a post-processing step. This parameter is only applied when precomputed signals_agg and signals_padded are not given. If you want to post-process your precomputed signals you need to do that before generating the report.}
 
 \item{title}{NULL or a character string. Specifies the title of the report that is to be created}
 }


### PR DESCRIPTION
I just added a description of the variable min_cases_signals that this post-processing is only used when the signals are computed inside the run_report. When already precomputed signals are provided then the signals_agg can't be filtered by those signals where the cases where above a threshold because it is already aggregated over multiple weeks. We could of course take the signals_padded filter this by the post-processing and then aggregate these again but this is an overkill I think if the user already provided aggregated signals.
What do you think? 