### PR TITLE
[BUG] Week in timeseries wrongly shown

### DIFF
--- a/R/plot_barchart.R
+++ b/R/plot_barchart.R
@@ -5,7 +5,6 @@
 #' @param signals_agg tibble, aggregated signals which can be obtained from using the function \code{\link{aggregate_signals}}. It contains the number of cases, any_alarms and n_alarms for one category, i.e. age group summed over the number of weeks used in \code{\link{aggregate_signals}}.
 #' @param interactive boolean identifying whether the plot should be static or interactive
 #' @param toggle_alarms boolean identifying whether the plot should showing number of signals explicitly or only when hovering
-#' @param partial logical, add partial bundle to plotly
 #' @returns either a gg or plotly object
 #' @examples
 #' \dontrun{
@@ -17,8 +16,7 @@
 #' }
 plot_barchart <- function(signals_agg,
                           interactive = TRUE,
-                          toggle_alarms = FALSE,
-                          partial = FALSE) {
+                          toggle_alarms = FALSE) {
   checkmate::assert(
     checkmate::check_true(interactive),
     checkmate::check_false(interactive),
@@ -114,10 +112,6 @@ plot_barchart <- function(signals_agg,
         "zoom2d",
         "toggleSpikelines"
       ))
-
-    if (partial) {
-      p <- plotly::partial_bundle(p)
-    }
   }
   return(p)
 }

--- a/R/plot_regional.R
+++ b/R/plot_regional.R
@@ -3,13 +3,11 @@
 #' @param signals_agg_unknown_region tibble default NULL, if not NULL tibble containing only the row for signals_agg for the missing regions (is.na(stratum)) with the columns cases and n_alarms which are used for creating the annotation text below the map
 #' @param interactive boolean identifying whether the plot should be static or interactive
 #' @param toggle_alarms boolean identifying whether the plot should showing number of signals explicitly or only when hovering
-#' @param partial logical, add partial bundle to plotly
 #' @returns either a ggplot object if static plot is chosen or a plotly object for the interactive plot
 plot_regional <- function(shape_with_signals,
                           signals_agg_unknown_region = NULL,
                           interactive = FALSE,
-                          toggle_alarms = FALSE,
-                          partial = FALSE) {
+                          toggle_alarms = FALSE) {
   checkmate::assertClass(shape_with_signals, "sf")
 
   checkmate::assert(
@@ -201,10 +199,6 @@ plot_regional <- function(shape_with_signals,
         "zoom2d",
         "toggleSpikelines"
       ))
-
-    if (partial) {
-      plot <- plotly::partial_bundle(plot)
-    }
   }
 
   plot

--- a/R/plot_signals_week.R
+++ b/R/plot_signals_week.R
@@ -6,7 +6,6 @@
 #' @param results dataframe of a single-pathogen signal detection results for a strata category
 #' @param interactive logical, if TRUE, interactive plot is returned; default, static plot.
 #' @param branding named vector with branding colours
-#' @param partial logical, add partial bundle to plotly
 #'
 #' @return either a ggplot or plotly object
 #'
@@ -17,7 +16,7 @@
 #'
 #' plot_signals_per_week(signals)
 #' }
-plot_signals_per_week <- function(results, interactive = FALSE, branding = NULL, partial = FALSE) {
+plot_signals_per_week <- function(results, interactive = FALSE, branding = NULL) {
   if (is.null(branding)) {
     branding <- stats::setNames(c("lightgray", "#be1622"), c("primary", "danger"))
   } else {
@@ -127,10 +126,6 @@ plot_signals_per_week <- function(results, interactive = FALSE, branding = NULL,
           xanchor = "center", yanchor = "bottom"
         )
       )
-
-    if (partial) {
-      p <- plotly::partial_bundle(p)
-    }
   }
 
   return(p)

--- a/R/plot_time_series.R
+++ b/R/plot_time_series.R
@@ -8,7 +8,6 @@
 #' @param interactive logical, if TRUE, interactive plot is returned; default, static plot.
 #' @param intervention_date A date object or character of format yyyy-mm-dd or NULL specifying the date for the intervention in the pandemic correction models. Default is NULL which indicates that no intervention is done.The  intervention is marked with a dashed line.
 #' @param number_of_weeks number of weeks to be covered in the plot
-#' @param partial logical, add partial bundle to plotly
 #'
 #' @return either a gg or plotly object
 #' @export
@@ -21,8 +20,7 @@
 #' }
 plot_time_series <- function(results, interactive = FALSE,
                              intervention_date = NULL,
-                             number_of_weeks = 52,
-                             partial = FALSE) {
+                             number_of_weeks = 52) {
   # check whether timeseries contains padding or not
   padding_upperbound <- "upperbound_pad" %in% colnames(results)
   padding_expected <- "expected_pad" %in% colnames(results)
@@ -390,10 +388,6 @@ plot_time_series <- function(results, interactive = FALSE,
     }
     # Update the plot with dynamic y-axis adjustment and x-axis bugfix
     plt <- update_axes(plt)
-
-    if (partial) {
-      plt <- plotly::partial_bundle(plt)
-    }
   } else {
     plt <-
       results %>%

--- a/R/visualisation_deciders.R
+++ b/R/visualisation_deciders.R
@@ -12,7 +12,6 @@
 #'   - By default, this parameter is set to `get_shp_config_or_internal()`, which handles this logic dynamically.
 #' @param interactive boolean identifying whether the plot should be static or interactive
 #' @param toggle_alarms boolean identifying whether the plot should showing number of signals explicitly or only when hovering
-#' @param partial logical, add partial bundle to plotly
 #' @returns a table or a plot depending on whether the matching of the NUTS IDs was fully possible, the table and plots can be interactive or not depening on the interactive parameter, can be class "ggplot" or "plotly" for plot and class "gt_tbl" or "datatables" for table
 #' @examples
 #' \dontrun{
@@ -27,8 +26,7 @@ create_map_or_table <- function(signals_agg,
                                 region,
                                 shape = get_shp_config_or_internal(),
                                 interactive = TRUE,
-                                toggle_alarms = FALSE,
-                                partial = FALSE) {
+                                toggle_alarms = FALSE) {
   checkmate::assertChoice(region, region_variable_names())
 
   checkmate::assert(
@@ -123,8 +121,7 @@ create_map_or_table <- function(signals_agg,
     output <- plot_regional(shape_with_signals,
       signals_agg_unknown_region,
       interactive = interactive,
-      toggle_alarms = toggle_alarms,
-      partial = partial
+      toggle_alarms = toggle_alarms
     )
   } else {
     format <- ifelse(interactive, "DataTable", "Flextable")
@@ -145,7 +142,6 @@ create_map_or_table <- function(signals_agg,
 #' @param n_levels the threshold for the number of levels from which we decide when a table is generated instead of a barchart visualisation
 #' @param interactive boolean identifying whether the plot should be static or interactive
 #' @param toggle_alarms boolean identifying whether the plot should showing number of signals explicitly or only when hovering
-#' @param partial logical, add partial bundle to plotly
 #' @returns a table or a plot depending on whether number of unique levels for the category to visualise, the table and plots can be interactive or not depening on the interactive parameter, can be class "ggplot" or "plotly" for plot and class "gt_tbl" or "datatables" for table
 #' @examples
 #' \dontrun{
@@ -159,8 +155,7 @@ create_barplot_or_table <- function(signals_agg,
                                     category_selected,
                                     n_levels = 25,
                                     interactive = TRUE,
-                                    toggle_alarms = FALSE,
-                                    partial = FALSE) {
+                                    toggle_alarms = FALSE) {
   signals_agg <- signals_agg %>%
     dplyr::filter(category == category_selected)
 
@@ -168,8 +163,7 @@ create_barplot_or_table <- function(signals_agg,
 
   if (n_levels_data < n_levels) {
     plot_barchart(signals_agg,
-      interactive = interactive, toggle_alarms = toggle_alarms,
-      partial = partial
+      interactive = interactive, toggle_alarms = toggle_alarms
     )
   } else {
     format <- ifelse(interactive, "DataTable", "Flextable")
@@ -189,30 +183,26 @@ create_barplot_or_table <- function(signals_agg,
 #' @param signal_category character, naming the category which should be visualised, i.e. "state","age_group","sex"
 #' @param interactive boolean identifying whether the plot should be static or interactive
 #' @param toggle_alarms boolean identifying whether the plot should showing number of signals explicitly or only when hovering
-#' @param partial logical, add partial bundle to plotly
 #' @return a table or a plot depending on signal_category, the table and plots can be interactive or not depening on the interactive parameter, can be class "ggplot" or "plotly" for plot and class "gt_tbl" or "datatables" for table
 decider_barplot_map_table <- function(signals_agg,
                                       data_surveillance,
                                       signal_category,
                                       interactive = TRUE,
-                                      toggle_alarms = FALSE,
-                                      partial = FALSE) {
+                                      toggle_alarms = FALSE) {
   if (signal_category %in% region_variable_names()) {
     plot_or_table <- create_map_or_table(
       signals_agg,
       data_surveillance,
       signal_category,
       interactive = interactive,
-      toggle_alarms = toggle_alarms,
-      partial = partial
+      toggle_alarms = toggle_alarms
     )
   } else {
     plot_or_table <- create_barplot_or_table(
       signals_agg,
       signal_category,
       interactive = interactive,
-      toggle_alarms = toggle_alarms,
-      partial = partial
+      toggle_alarms = toggle_alarms
     )
   }
   return(plot_or_table)

--- a/inst/report/html_report/SignalDetectionReport_body.Rmd
+++ b/inst/report/html_report/SignalDetectionReport_body.Rmd
@@ -98,7 +98,7 @@ for(cate in params$strata){
   
   p <- s_pad %>% 
     dplyr::filter(category == cate) %>% 
-    plot_signals_per_week(interactive = TRUE, branding = brand_colors, partial = FALSE )
+    plot_signals_per_week(interactive = TRUE, branding = brand_colors)
   
   print(htmltools::tagList(p))
   
@@ -119,8 +119,7 @@ for(cate in params$strata){
      s_agg,
      params$data,
      cate,
-     interactive = TRUE,
-     partial = FALSE 
+     interactive = TRUE
     ) 
   
   print(htmltools::tagList(dist_plot))
@@ -138,8 +137,7 @@ SignalDetectionTool::plot_time_series(
   s_pad %>%
     dplyr::filter(is.na(category)),
   intervention_date = params$intervention_date,
-  interactive = TRUE,
-  partial = FALSE 
+  interactive = TRUE
 )
 ```
 

--- a/inst/report/html_report/SignalDetectionReport_body.Rmd
+++ b/inst/report/html_report/SignalDetectionReport_body.Rmd
@@ -98,7 +98,7 @@ for(cate in params$strata){
   
   p <- s_pad %>% 
     dplyr::filter(category == cate) %>% 
-    plot_signals_per_week(interactive = TRUE, branding = brand_colors, partial = TRUE)
+    plot_signals_per_week(interactive = TRUE, branding = brand_colors, partial = FALSE )
   
   print(htmltools::tagList(p))
   
@@ -120,7 +120,7 @@ for(cate in params$strata){
      params$data,
      cate,
      interactive = TRUE,
-     partial = TRUE
+     partial = FALSE 
     ) 
   
   print(htmltools::tagList(dist_plot))
@@ -139,7 +139,7 @@ SignalDetectionTool::plot_time_series(
     dplyr::filter(is.na(category)),
   intervention_date = params$intervention_date,
   interactive = TRUE,
-  partial = TRUE
+  partial = FALSE 
 )
 ```
 

--- a/inst/report/html_report/SignalDetectionReport_strata.Rmd
+++ b/inst/report/html_report/SignalDetectionReport_strata.Rmd
@@ -77,8 +77,7 @@ for(st in unique(df$stratum)){
     df %>% dplyr::filter(.data[["stratum"]] == st),
     number_of_weeks = 52,
     intervention_date = params$intervention_date,
-    interactive = TRUE,
-    partial = FALSE
+    interactive = TRUE
     )
 
   print(htmltools::tagList(plot_stratum))

--- a/inst/report/html_report/SignalDetectionReport_strata.Rmd
+++ b/inst/report/html_report/SignalDetectionReport_strata.Rmd
@@ -78,7 +78,7 @@ for(st in unique(df$stratum)){
     number_of_weeks = 52,
     intervention_date = params$intervention_date,
     interactive = TRUE,
-    partial = TRUE
+    partial = FALSE
     )
 
   print(htmltools::tagList(plot_stratum))

--- a/man/create_barplot_or_table.Rd
+++ b/man/create_barplot_or_table.Rd
@@ -10,8 +10,7 @@ create_barplot_or_table(
   category_selected,
   n_levels = 25,
   interactive = TRUE,
-  toggle_alarms = FALSE,
-  partial = FALSE
+  toggle_alarms = FALSE
 )
 }
 \arguments{
@@ -24,8 +23,6 @@ create_barplot_or_table(
 \item{interactive}{boolean identifying whether the plot should be static or interactive}
 
 \item{toggle_alarms}{boolean identifying whether the plot should showing number of signals explicitly or only when hovering}
-
-\item{partial}{logical, add partial bundle to plotly}
 }
 \value{
 a table or a plot depending on whether number of unique levels for the category to visualise, the table and plots can be interactive or not depening on the interactive parameter, can be class "ggplot" or "plotly" for plot and class "gt_tbl" or "datatables" for table

--- a/man/create_map_or_table.Rd
+++ b/man/create_map_or_table.Rd
@@ -10,8 +10,7 @@ create_map_or_table(
   region,
   shape = get_shp_config_or_internal(),
   interactive = TRUE,
-  toggle_alarms = FALSE,
-  partial = FALSE
+  toggle_alarms = FALSE
 )
 }
 \arguments{
@@ -30,8 +29,6 @@ create_map_or_table(
 \item{interactive}{boolean identifying whether the plot should be static or interactive}
 
 \item{toggle_alarms}{boolean identifying whether the plot should showing number of signals explicitly or only when hovering}
-
-\item{partial}{logical, add partial bundle to plotly}
 }
 \value{
 a table or a plot depending on whether the matching of the NUTS IDs was fully possible, the table and plots can be interactive or not depening on the interactive parameter, can be class "ggplot" or "plotly" for plot and class "gt_tbl" or "datatables" for table

--- a/man/decider_barplot_map_table.Rd
+++ b/man/decider_barplot_map_table.Rd
@@ -9,8 +9,7 @@ decider_barplot_map_table(
   data_surveillance,
   signal_category,
   interactive = TRUE,
-  toggle_alarms = FALSE,
-  partial = FALSE
+  toggle_alarms = FALSE
 )
 }
 \arguments{
@@ -23,8 +22,6 @@ decider_barplot_map_table(
 \item{interactive}{boolean identifying whether the plot should be static or interactive}
 
 \item{toggle_alarms}{boolean identifying whether the plot should showing number of signals explicitly or only when hovering}
-
-\item{partial}{logical, add partial bundle to plotly}
 }
 \value{
 a table or a plot depending on signal_category, the table and plots can be interactive or not depening on the interactive parameter, can be class "ggplot" or "plotly" for plot and class "gt_tbl" or "datatables" for table

--- a/man/plot_barchart.Rd
+++ b/man/plot_barchart.Rd
@@ -4,12 +4,7 @@
 \alias{plot_barchart}
 \title{Barplot visualising the number of cases and information about any signals}
 \usage{
-plot_barchart(
-  signals_agg,
-  interactive = TRUE,
-  toggle_alarms = FALSE,
-  partial = FALSE
-)
+plot_barchart(signals_agg, interactive = TRUE, toggle_alarms = FALSE)
 }
 \arguments{
 \item{signals_agg}{tibble, aggregated signals which can be obtained from using the function \code{\link{aggregate_signals}}. It contains the number of cases, any_alarms and n_alarms for one category, i.e. age group summed over the number of weeks used in \code{\link{aggregate_signals}}.}
@@ -17,8 +12,6 @@ plot_barchart(
 \item{interactive}{boolean identifying whether the plot should be static or interactive}
 
 \item{toggle_alarms}{boolean identifying whether the plot should showing number of signals explicitly or only when hovering}
-
-\item{partial}{logical, add partial bundle to plotly}
 }
 \value{
 either a gg or plotly object

--- a/man/plot_regional.Rd
+++ b/man/plot_regional.Rd
@@ -8,8 +8,7 @@ plot_regional(
   shape_with_signals,
   signals_agg_unknown_region = NULL,
   interactive = FALSE,
-  toggle_alarms = FALSE,
-  partial = FALSE
+  toggle_alarms = FALSE
 )
 }
 \arguments{
@@ -20,8 +19,6 @@ plot_regional(
 \item{interactive}{boolean identifying whether the plot should be static or interactive}
 
 \item{toggle_alarms}{boolean identifying whether the plot should showing number of signals explicitly or only when hovering}
-
-\item{partial}{logical, add partial bundle to plotly}
 }
 \value{
 either a ggplot object if static plot is chosen or a plotly object for the interactive plot

--- a/man/plot_signals_per_week.Rd
+++ b/man/plot_signals_per_week.Rd
@@ -4,12 +4,7 @@
 \alias{plot_signals_per_week}
 \title{Plot in how many strata an signal was detected under the detection period}
 \usage{
-plot_signals_per_week(
-  results,
-  interactive = FALSE,
-  branding = NULL,
-  partial = FALSE
-)
+plot_signals_per_week(results, interactive = FALSE, branding = NULL)
 }
 \arguments{
 \item{results}{dataframe of a single-pathogen signal detection results for a strata category}
@@ -17,8 +12,6 @@ plot_signals_per_week(
 \item{interactive}{logical, if TRUE, interactive plot is returned; default, static plot.}
 
 \item{branding}{named vector with branding colours}
-
-\item{partial}{logical, add partial bundle to plotly}
 }
 \value{
 either a ggplot or plotly object

--- a/man/plot_time_series.Rd
+++ b/man/plot_time_series.Rd
@@ -8,8 +8,7 @@ plot_time_series(
   results,
   interactive = FALSE,
   intervention_date = NULL,
-  number_of_weeks = 52,
-  partial = FALSE
+  number_of_weeks = 52
 )
 }
 \arguments{
@@ -20,8 +19,6 @@ plot_time_series(
 \item{intervention_date}{A date object or character of format yyyy-mm-dd or NULL specifying the date for the intervention in the pandemic correction models. Default is NULL which indicates that no intervention is done.The  intervention is marked with a dashed line.}
 
 \item{number_of_weeks}{number of weeks to be covered in the plot}
-
-\item{partial}{logical, add partial bundle to plotly}
 }
 \value{
 either a gg or plotly object


### PR DESCRIPTION
Inspection of the timeseries data in html shows the dates are there, is rather the rendering of the date in the tooltip what is not functioning correctly. The other timeseries in strata pages are shown correctly. Also, running the function with the unstratified data outside the Report shows the correct labels.

I assume it is a problem related to the partial_bundle parameter we had added to reduce the size of the original report. Deactivating this parameter seems to solve the problem. Comparing the size of the generated zip show actually a decrease when not using partial bundle (extra dependency plotly_basic is added to lib when using this parameter) 

We can decide if we rather remove partial_bundle from everywhere in the package
