### PR TITLE
add marker to timeseries of strata with signals

### DIFF
--- a/R/run_report.R
+++ b/R/run_report.R
@@ -418,12 +418,15 @@ run_report <- function(
         # strata pages parameters
         signals_pad_c <-  signals_padded %>%
           dplyr::filter(.data$pathogen == patho, .data$category == ctg)
+        signals_agg_c <- signals_agg_p %>%
+          dplyr::filter(.data$category == ctg)
 
         strata_report_params <- list(
           disease = patho,
           country = unique(data$country),
           number_of_weeks = number_of_weeks,
           category = ctg,
+          signals_agg = signals_agg_c,
           signals_padded = signals_pad_c,
           intervention_date = intervention_date,
           title = title

--- a/inst/report/html_report/SignalDetectionReport_strata.Rmd
+++ b/inst/report/html_report/SignalDetectionReport_strata.Rmd
@@ -8,7 +8,8 @@ params:
   disease: "Pertussis"
   country: "Austria"
   number_of_weeks: 6
-  category: "age_group" 
+  category: "age_group"
+  signals_agg: NULL 
   signals_padded: NULL
   intervention_date: NULL
   title: "Signal Detection Report"
@@ -32,6 +33,10 @@ strat_text <- dplyr::case_when(
 ```
 
 ```{r}
+# stratum with signals
+s_df <- params$signals_agg %>% 
+  SignalDetectionTool:::create_factor_with_unknown()
+
 df <- params$signals_padded %>%
   dplyr::filter(.data$category %in% categ) %>%
   SignalDetectionTool:::create_factor_with_unknown()
@@ -71,7 +76,13 @@ tabrows <- ceiling(nchar(characters_strata)/155)
 
 ```{r, results='asis'}
 for(st in unique(df$stratum)){
-  cat("###", st, "\n")
+  # add marker to stratum with signals
+  if(s_df$any_alarms[s_df$stratum == st]){
+    st_f <- paste0("<b>\U2605 ", st, "</b>")
+  } else {
+    st_f <- st
+  }
+  cat("###", st_f, "\n")
   
   plot_stratum <- plot_time_series(
     df %>% dplyr::filter(.data[["stratum"]] == st),


### PR DESCRIPTION
To avoid going back and forth between pathogen and strata pages, now timeseries in strata pages have a marker to identify which stratum has a signal.