### PR TITLE
Fix/signal position  bug #414

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
   * fix bug in tooltip not showing the week correctly in unstratified time series in report
   * fix wrong number of total cases in html report landing page
   * fix signals tables being scrollable again 
+  * fix positions of signals not appearing outside other regions 
 * Shortening of long x axis labels in barcharts and adding complete axis text to tooltip
 
 

--- a/R/plot_regional.R
+++ b/R/plot_regional.R
@@ -158,7 +158,7 @@ plot_regional <- function(shape_with_signals,
         mutate(
           geometry = {
             pt <- geometry
-            self  <- shape_areas_sf[shape_areas_sf$NUTS_ID == NUTS_ID, ]
+            self <- shape_areas_sf[shape_areas_sf$NUTS_ID == NUTS_ID, ]
             other <- shape_areas_sf[shape_areas_sf$NUTS_ID != NUTS_ID, ]
 
             hit_other <- lengths(sf::st_intersects(pt, other)) > 0
@@ -167,8 +167,9 @@ plot_regional <- function(shape_with_signals,
               pt
             } else {
               safe <- sf::st_difference(sf::st_geometry(self), sf::st_union(sf::st_geometry(other)))
-              if (length(safe) == 0 || sf::st_is_empty(safe)) sf::st_point_on_surface(self)
-              else {
+              if (length(safe) == 0 || sf::st_is_empty(safe)) {
+                sf::st_point_on_surface(self)
+              } else {
                 if (length(safe) > 1) safe <- safe[which.max(sf::st_area(safe))]
                 sf::st_point_on_surface(safe)
               }

--- a/R/plot_regional.R
+++ b/R/plot_regional.R
@@ -153,8 +153,6 @@ plot_regional <- function(shape_with_signals,
         sf::st_collection_extract("POINT") |> # only keep points
         dplyr::filter(!sf::st_is_empty(geometry)) # remove empty ones
 
-      # others_all <- sf::st_union(sf::st_geometry(shape_areas_sf))
-
       stars_sf <- stars_sf |>
         rowwise() |>
         mutate(

--- a/R/plot_regional.R
+++ b/R/plot_regional.R
@@ -153,6 +153,32 @@ plot_regional <- function(shape_with_signals,
         sf::st_collection_extract("POINT") |> # only keep points
         dplyr::filter(!sf::st_is_empty(geometry)) # remove empty ones
 
+      # others_all <- sf::st_union(sf::st_geometry(shape_areas_sf))
+
+      stars_sf <- stars_sf |>
+        rowwise() |>
+        mutate(
+          geometry = {
+            pt <- geometry
+            self  <- shape_areas_sf[shape_areas_sf$NUTS_ID == NUTS_ID, ]
+            other <- shape_areas_sf[shape_areas_sf$NUTS_ID != NUTS_ID, ]
+
+            hit_other <- lengths(sf::st_intersects(pt, other)) > 0
+
+            if (!hit_other) {
+              pt
+            } else {
+              safe <- sf::st_difference(sf::st_geometry(self), sf::st_union(sf::st_geometry(other)))
+              if (length(safe) == 0 || sf::st_is_empty(safe)) sf::st_point_on_surface(self)
+              else {
+                if (length(safe) > 1) safe <- safe[which.max(sf::st_area(safe))]
+                sf::st_point_on_surface(safe)
+              }
+            }
+          }
+        ) |>
+        ungroup()
+
       sf::sf_use_s2(old_s2)
 
       if (nrow(stars_sf) < nrow_stars_before) {


### PR DESCRIPTION
This bug-fix adresses bug #414. Centroid points are now validated against all other geometries.
If a centroid intersects another region, it is replaced by a point on the largest non-overlapping polygon remainder.