### PR TITLE
Fix/longer signals table

### DIFF
--- a/R/results_table.R
+++ b/R/results_table.R
@@ -42,7 +42,7 @@ get_float_columns <- function(data) {
 #' @param interactive Logical indicating whether to create an interactive
 #'   DataTable (default is TRUE).
 #' @param dt_selection_type String controlling the DataTable selection argument. Expected values are "multiple", "single", "none" (default is 'single').
-#'
+#' @param page_length integer indicating number of elements per DataTable page. Default is 10
 #' @return An interactive DataTable or a static gt table, depending on the value
 #'   of `interactive`.
 #'
@@ -70,7 +70,7 @@ get_float_columns <- function(data) {
 #' format_table(data_agg)
 #' }
 format_table <- function(data, signals_only = TRUE, interactive = TRUE,
-                         dt_selection_type = "single") {
+                         dt_selection_type = "single", page_length = 10) {
   checkmate::assert(
     checkmate::check_true(interactive),
     checkmate::check_false(interactive),
@@ -130,7 +130,7 @@ format_table <- function(data, signals_only = TRUE, interactive = TRUE,
       selection = dt_selection_type,
       fillContainer = TRUE,
       options = list(
-        pageLength = 10,
+        pageLength = page_length,
         rowGroup = list(dataSrc = 0),
         columnDefs = list(list(visible = FALSE, targets = 0)),
         dom = "tfrBip",
@@ -263,6 +263,7 @@ prepare_signals_table <- function(data,
 #'   - `"DataTable"`: An interactive table using the DataTable library.
 #'   - `"Flextable"`: A formatted table suitable for reporting,i.e. word documents.
 #'  Default is "DataTable".
+#'  @param page_length integer indicating number of elements per DataTable page. Default is 10
 #'
 #' @param dt_selection_type String controlling the DataTable selection argument. Expected values are "multiple", "single", "none" (default is 'single').
 #' @return data.frame or DataTable or Flextable depending on `format`
@@ -279,7 +280,8 @@ prepare_signals_table <- function(data,
 build_signals_table <- function(signal_results,
                                 signals_only = TRUE,
                                 format = "DataTable",
-                                dt_selection_type = "single") {
+                                dt_selection_type = "single",
+                                page_length = 10) {
   checkmate::assert(
     checkmate::check_choice(format, choices = c(
       "data.frame",
@@ -305,7 +307,7 @@ build_signals_table <- function(signal_results,
     table <- table %>%
       format_table(
         signals_only = signals_only, interactive = TRUE,
-        dt_selection_type = dt_selection_type
+        dt_selection_type = dt_selection_type, page_length = page_length
       )
   }
   if (format == "Flextable") {
@@ -393,6 +395,7 @@ prepare_signals_agg_table <- function(signals_agg) {
 #'   - `"DataTable"`: An interactive table using the DataTable library.
 #'   - `"Flextable"`: A formatted table suitable for reporting,i.e. word documents.
 #'   Default is "DataTable".
+#' @param page_length integer indicating number of elements per DataTable page. Default is 10 description
 #'
 #' @return data.frame or DataTable or Flextable depending on `format`
 #'
@@ -409,7 +412,8 @@ prepare_signals_agg_table <- function(signals_agg) {
 #' build_signals_agg_table(signals_agg)
 #' }
 build_signals_agg_table <- function(signals_agg,
-                                    format = "DataTable") {
+                                    format = "DataTable",
+                                    page_length = 10) {
   checkmate::assert(
     checkmate::check_choice(format, choices = c(
       "data.frame",
@@ -422,7 +426,7 @@ build_signals_agg_table <- function(signals_agg,
 
   if (format == "DataTable") {
     table <- table %>%
-      format_table(signals_only = TRUE, interactive = TRUE)
+      format_table(signals_only = TRUE, interactive = TRUE, page_length = page_length)
   }
   if (format == "Flextable") {
     table <- table %>%

--- a/R/results_table.R
+++ b/R/results_table.R
@@ -263,7 +263,7 @@ prepare_signals_table <- function(data,
 #'   - `"DataTable"`: An interactive table using the DataTable library.
 #'   - `"Flextable"`: A formatted table suitable for reporting,i.e. word documents.
 #'  Default is "DataTable".
-#'  @param page_length integer indicating number of elements per DataTable page. Default is 10
+#' @param page_length integer indicating number of elements per DataTable page. Default is 10
 #'
 #' @param dt_selection_type String controlling the DataTable selection argument. Expected values are "multiple", "single", "none" (default is 'single').
 #' @return data.frame or DataTable or Flextable depending on `format`

--- a/R/visualisation_deciders.R
+++ b/R/visualisation_deciders.R
@@ -11,6 +11,7 @@
 #'   - Otherwise, the function defaults to the internal European shapefile (`nuts_shp`).
 #'   - By default, this parameter is set to `get_shp_config_or_internal()`, which handles this logic dynamically.
 #' @param interactive boolean identifying whether the plot should be static or interactive
+#' @param page_length integer indicating number of elements per DataTable page. Default is 10
 #' @param toggle_alarms boolean identifying whether the plot should showing number of signals explicitly or only when hovering
 #' @returns a table or a plot depending on whether the matching of the NUTS IDs was fully possible, the table and plots can be interactive or not depening on the interactive parameter, can be class "ggplot" or "plotly" for plot and class "gt_tbl" or "datatables" for table
 #' @examples
@@ -26,6 +27,7 @@ create_map_or_table <- function(signals_agg,
                                 region,
                                 shape = get_shp_config_or_internal(),
                                 interactive = TRUE,
+                                page_length = 10,
                                 toggle_alarms = FALSE) {
   checkmate::assertChoice(region, region_variable_names())
 
@@ -127,7 +129,8 @@ create_map_or_table <- function(signals_agg,
     format <- ifelse(interactive, "DataTable", "Flextable")
     output <- build_signals_agg_table(
       signals_agg,
-      format = format
+      format = format,
+      page_length = page_length
     )
   }
 
@@ -141,6 +144,7 @@ create_map_or_table <- function(signals_agg,
 #' @param category_selected the category from the signals_agg we want to visualise
 #' @param n_levels the threshold for the number of levels from which we decide when a table is generated instead of a barchart visualisation
 #' @param interactive boolean identifying whether the plot should be static or interactive
+#' @param page_length integer indicating number of elements per DataTable page. Default is 10
 #' @param toggle_alarms boolean identifying whether the plot should showing number of signals explicitly or only when hovering
 #' @returns a table or a plot depending on whether number of unique levels for the category to visualise, the table and plots can be interactive or not depening on the interactive parameter, can be class "ggplot" or "plotly" for plot and class "gt_tbl" or "datatables" for table
 #' @examples
@@ -155,6 +159,7 @@ create_barplot_or_table <- function(signals_agg,
                                     category_selected,
                                     n_levels = 25,
                                     interactive = TRUE,
+                                    page_length = 10,
                                     toggle_alarms = FALSE) {
   signals_agg <- signals_agg %>%
     dplyr::filter(category == category_selected)
@@ -169,7 +174,8 @@ create_barplot_or_table <- function(signals_agg,
     format <- ifelse(interactive, "DataTable", "Flextable")
     build_signals_agg_table(
       signals_agg,
-      format = format
+      format = format,
+      page_length = page_length
     )
   }
 }
@@ -182,12 +188,14 @@ create_barplot_or_table <- function(signals_agg,
 #' @param data_surveillance data.frame, surveillance linelist
 #' @param signal_category character, naming the category which should be visualised, i.e. "state","age_group","sex"
 #' @param interactive boolean identifying whether the plot should be static or interactive
+#' @param page_length integer indicating number of elements per DataTable page. Default is 10
 #' @param toggle_alarms boolean identifying whether the plot should showing number of signals explicitly or only when hovering
 #' @return a table or a plot depending on signal_category, the table and plots can be interactive or not depening on the interactive parameter, can be class "ggplot" or "plotly" for plot and class "gt_tbl" or "datatables" for table
 decider_barplot_map_table <- function(signals_agg,
                                       data_surveillance,
                                       signal_category,
                                       interactive = TRUE,
+                                      page_length = 10,
                                       toggle_alarms = FALSE) {
   if (signal_category %in% region_variable_names()) {
     plot_or_table <- create_map_or_table(
@@ -195,6 +203,7 @@ decider_barplot_map_table <- function(signals_agg,
       data_surveillance,
       signal_category,
       interactive = interactive,
+      page_length = page_length,
       toggle_alarms = toggle_alarms
     )
   } else {
@@ -202,6 +211,7 @@ decider_barplot_map_table <- function(signals_agg,
       signals_agg,
       signal_category,
       interactive = interactive,
+      page_length = page_length,
       toggle_alarms = toggle_alarms
     )
   }

--- a/inst/report/html_report/SignalDetectionReport_body.Rmd
+++ b/inst/report/html_report/SignalDetectionReport_body.Rmd
@@ -143,7 +143,7 @@ SignalDetectionTool::plot_time_series(
 
 > `r paste("Number of", params$disease, "cases by week and signals,", params$country)`
 
-Row 
+Row {data-height=700}
 -------------------------------------
 ### Signal Detection Table
 

--- a/inst/report/html_report/SignalDetectionReport_body.Rmd
+++ b/inst/report/html_report/SignalDetectionReport_body.Rmd
@@ -119,7 +119,8 @@ for(cate in params$strata){
      s_agg,
      params$data,
      cate,
-     interactive = TRUE
+     interactive = TRUE, 
+     page_length = 5
     ) 
   
   print(htmltools::tagList(dist_plot))
@@ -143,7 +144,7 @@ SignalDetectionTool::plot_time_series(
 
 > `r paste("Number of", params$disease, "cases by week and signals,", params$country)`
 
-Row {data-height=700}
+Row {data-height=800}
 -------------------------------------
 ### Signal Detection Table
 
@@ -153,7 +154,8 @@ txt <- NULL
 if (sum(results_analysis$alarms, na.rm = TRUE) != 0) {
   SignalDetectionTool::build_signals_table(
     s_pad,
-    format = "DataTable"
+    format = "DataTable", 
+    page_length = 15
   )
 } else {
   txt <- "No signals were detected."

--- a/man/build_signals_agg_table.Rd
+++ b/man/build_signals_agg_table.Rd
@@ -4,7 +4,7 @@
 \alias{build_signals_agg_table}
 \title{Builds the aggregated signal detection results table with different formating options.}
 \usage{
-build_signals_agg_table(signals_agg, format = "DataTable")
+build_signals_agg_table(signals_agg, format = "DataTable", page_length = 10)
 }
 \arguments{
 \item{signals_agg}{A tibble or data.frame containing aggregated signals produced from \link{aggregate_signals}(signals,number_of_weeks = 6).}
@@ -14,6 +14,8 @@ build_signals_agg_table(signals_agg, format = "DataTable")
 - `"DataTable"`: An interactive table using the DataTable library.
 - `"Flextable"`: A formatted table suitable for reporting,i.e. word documents.
 Default is "DataTable".}
+
+\item{page_length}{integer indicating number of elements per DataTable page. Default is 10 description}
 }
 \value{
 data.frame or DataTable or Flextable depending on `format`

--- a/man/build_signals_table.Rd
+++ b/man/build_signals_table.Rd
@@ -21,10 +21,11 @@ build_signals_table(
  - `"data.frame"`: A standard R data frame.
  - `"DataTable"`: An interactive table using the DataTable library.
  - `"Flextable"`: A formatted table suitable for reporting,i.e. word documents.
-Default is "DataTable".
-@param page_length integer indicating number of elements per DataTable page. Default is 10}
+Default is "DataTable".}
 
 \item{dt_selection_type}{String controlling the DataTable selection argument. Expected values are "multiple", "single", "none" (default is 'single').}
+
+\item{page_length}{integer indicating number of elements per DataTable page. Default is 10}
 }
 \value{
 data.frame or DataTable or Flextable depending on `format`

--- a/man/build_signals_table.Rd
+++ b/man/build_signals_table.Rd
@@ -8,7 +8,8 @@ build_signals_table(
   signal_results,
   signals_only = TRUE,
   format = "DataTable",
-  dt_selection_type = "single"
+  dt_selection_type = "single",
+  page_length = 10
 )
 }
 \arguments{
@@ -20,7 +21,8 @@ build_signals_table(
  - `"data.frame"`: A standard R data frame.
  - `"DataTable"`: An interactive table using the DataTable library.
  - `"Flextable"`: A formatted table suitable for reporting,i.e. word documents.
-Default is "DataTable".}
+Default is "DataTable".
+@param page_length integer indicating number of elements per DataTable page. Default is 10}
 
 \item{dt_selection_type}{String controlling the DataTable selection argument. Expected values are "multiple", "single", "none" (default is 'single').}
 }

--- a/man/create_barplot_or_table.Rd
+++ b/man/create_barplot_or_table.Rd
@@ -10,6 +10,7 @@ create_barplot_or_table(
   category_selected,
   n_levels = 25,
   interactive = TRUE,
+  page_length = 10,
   toggle_alarms = FALSE
 )
 }
@@ -21,6 +22,8 @@ create_barplot_or_table(
 \item{n_levels}{the threshold for the number of levels from which we decide when a table is generated instead of a barchart visualisation}
 
 \item{interactive}{boolean identifying whether the plot should be static or interactive}
+
+\item{page_length}{integer indicating number of elements per DataTable page. Default is 10}
 
 \item{toggle_alarms}{boolean identifying whether the plot should showing number of signals explicitly or only when hovering}
 }

--- a/man/create_map_or_table.Rd
+++ b/man/create_map_or_table.Rd
@@ -10,6 +10,7 @@ create_map_or_table(
   region,
   shape = get_shp_config_or_internal(),
   interactive = TRUE,
+  page_length = 10,
   toggle_alarms = FALSE
 )
 }
@@ -27,6 +28,8 @@ create_map_or_table(
 - By default, this parameter is set to `get_shp_config_or_internal()`, which handles this logic dynamically.}
 
 \item{interactive}{boolean identifying whether the plot should be static or interactive}
+
+\item{page_length}{integer indicating number of elements per DataTable page. Default is 10}
 
 \item{toggle_alarms}{boolean identifying whether the plot should showing number of signals explicitly or only when hovering}
 }

--- a/man/decider_barplot_map_table.Rd
+++ b/man/decider_barplot_map_table.Rd
@@ -9,6 +9,7 @@ decider_barplot_map_table(
   data_surveillance,
   signal_category,
   interactive = TRUE,
+  page_length = 10,
   toggle_alarms = FALSE
 )
 }
@@ -20,6 +21,8 @@ decider_barplot_map_table(
 \item{signal_category}{character, naming the category which should be visualised, i.e. "state","age_group","sex"}
 
 \item{interactive}{boolean identifying whether the plot should be static or interactive}
+
+\item{page_length}{integer indicating number of elements per DataTable page. Default is 10}
 
 \item{toggle_alarms}{boolean identifying whether the plot should showing number of signals explicitly or only when hovering}
 }

--- a/man/format_table.Rd
+++ b/man/format_table.Rd
@@ -8,7 +8,8 @@ format_table(
   data,
   signals_only = TRUE,
   interactive = TRUE,
-  dt_selection_type = "single"
+  dt_selection_type = "single",
+  page_length = 10
 )
 }
 \arguments{
@@ -20,6 +21,8 @@ format_table(
 DataTable (default is TRUE).}
 
 \item{dt_selection_type}{String controlling the DataTable selection argument. Expected values are "multiple", "single", "none" (default is 'single').}
+
+\item{page_length}{integer indicating number of elements per DataTable page. Default is 10}
 }
 \value{
 An interactive DataTable or a static gt table, depending on the value


### PR DESCRIPTION
Increased the size and number of elements per page of the Signals Detection Table. 
This introduced the option of also deciding how many rows we allow for the strata distribution table (in case a barplot is not possible to be created).
The selected number of elements per page are 15 (in the unaggregated signals table) and 5 (for the stratified)