### PR TITLE
fix/uniform_signals_per_week

### DIFF
--- a/R/plot_signals_week.R
+++ b/R/plot_signals_week.R
@@ -14,8 +14,9 @@
 #' \dontrun{
 #' dat <- preprocess_data(input_example)
 #' signals <- get_signals(dat, stratification = "county")
+#' n.strata <- 9
 #'
-#' plot_signals_per_week(signals)
+#' plot_signals_per_week(signals, n_strata = n.strata)
 #' }
 plot_signals_per_week <- function(results, n_strata, interactive = FALSE, branding = NULL) {
   if (is.null(branding)) {

--- a/R/plot_signals_week.R
+++ b/R/plot_signals_week.R
@@ -4,6 +4,7 @@
 #' strata had higher than expected case numbers
 #'
 #' @param results dataframe of a single-pathogen signal detection results for a strata category
+#' @param n_strata integer. Number of stratification levels in category. Usually determined automatically by signals_agg
 #' @param interactive logical, if TRUE, interactive plot is returned; default, static plot.
 #' @param branding named vector with branding colours
 #'
@@ -16,7 +17,7 @@
 #'
 #' plot_signals_per_week(signals)
 #' }
-plot_signals_per_week <- function(results, interactive = FALSE, branding = NULL) {
+plot_signals_per_week <- function(results, n_strata, interactive = FALSE, branding = NULL) {
   if (is.null(branding)) {
     branding <- stats::setNames(c("lightgray", "#be1622"), c("primary", "danger"))
   } else {
@@ -41,8 +42,8 @@ plot_signals_per_week <- function(results, interactive = FALSE, branding = NULL)
     dplyr::group_by(.data$isoweek) %>%
     dplyr::summarise(
       n.signals = sum(.data$alarms),
-      n.rest = dplyr::n() - .data$n.signals,
-      p.signals = sum(.data$alarms) / dplyr::n() * 100 %>% round(1),
+      n.rest = n_strata - .data$n.signals,
+      p.signals = sum(.data$alarms) / n_strata * 100 %>% round(1),
       p.rest = 100 - .data$p.signals
     ) %>%
     dplyr::ungroup()

--- a/inst/report/html_report/SignalDetectionReport_body.Rmd
+++ b/inst/report/html_report/SignalDetectionReport_body.Rmd
@@ -53,6 +53,10 @@ s_pad <- params$signals_padded %>%
 ```{r}
 results_analysis <- s_pad %>%
   dplyr::filter(!is.na(alarms))
+
+strata_per_category <- s_agg %>% 
+  dplyr::count(.data$category)
+  
 ```
 
 Row
@@ -96,9 +100,11 @@ for(cate in params$strata){
   cate_link <- paste0("[", cate, "](",pate ,"-", cate, ".html)")
   cat("### Signals in", cate_link, "\n\n")
   
+  n.strata <- strata_per_category$n[strata_per_category$category == cate]
+  
   p <- s_pad %>% 
     dplyr::filter(category == cate) %>% 
-    plot_signals_per_week(interactive = TRUE, branding = brand_colors)
+    plot_signals_per_week(n_strata = n.strata, interactive = TRUE, branding = brand_colors)
   
   print(htmltools::tagList(p))
   

--- a/inst/report/html_report/SignalDetectionReport_body.Rmd
+++ b/inst/report/html_report/SignalDetectionReport_body.Rmd
@@ -100,7 +100,9 @@ for(cate in params$strata){
   cate_link <- paste0("[", cate, "](",pate ,"-", cate, ".html)")
   cat("### Signals in", cate_link, "\n\n")
   
-  n.strata <- strata_per_category$n[strata_per_category$category == cate]
+  n.strata <- strata_per_category %>%
+    dplyr::filter(category == cate) %>% 
+    dplyr::pull(n)
   
   p <- s_pad %>% 
     dplyr::filter(category == cate) %>% 

--- a/man/plot_signals_per_week.Rd
+++ b/man/plot_signals_per_week.Rd
@@ -4,10 +4,12 @@
 \alias{plot_signals_per_week}
 \title{Plot in how many strata an signal was detected under the detection period}
 \usage{
-plot_signals_per_week(results, interactive = FALSE, branding = NULL)
+plot_signals_per_week(results, n_strata, interactive = FALSE, branding = NULL)
 }
 \arguments{
 \item{results}{dataframe of a single-pathogen signal detection results for a strata category}
+
+\item{n_strata}{integer. Number of stratification levels in category. Usually determined automatically by signals_agg}
 
 \item{interactive}{logical, if TRUE, interactive plot is returned; default, static plot.}
 

--- a/man/plot_signals_per_week.Rd
+++ b/man/plot_signals_per_week.Rd
@@ -26,7 +26,8 @@ strata had higher than expected case numbers
 \dontrun{
 dat <- preprocess_data(input_example)
 signals <- get_signals(dat, stratification = "county")
+n.strata <- 9
 
-plot_signals_per_week(signals)
+plot_signals_per_week(signals, n_strata = n.strata)
 }
 }


### PR DESCRIPTION
I was not able to reproduce this bug, but looking at the function that plots the signals per week, the number of possible signals is determined by the available strata on each week. I changed it so the number is constant and determined using the categories in signals_agg, as it should contain all possible stratifications for each category.

can somebody test to see if the problem is solved using all the pathogens in the configurator?