### PR TITLE
Fix/pipe operator

### DIFF
--- a/R/data_processing.R
+++ b/R/data_processing.R
@@ -167,13 +167,13 @@ aggregate_data <- function(data,
       dplyr::left_join(data_outbreak_agg, by = c("cw_iso", group)) %>%
       dplyr::mutate(cases_in_outbreak = dplyr::if_else(is.na(cases_in_outbreak), 0, cases_in_outbreak))
   }
-  data_agg |>
-    tidyr::separate_wider_delim(cw_iso, delim = "-", names = c("year", "week")) |>
+  data_agg %>%
+    tidyr::separate_wider_delim(cw_iso, delim = "-", names = c("year", "week")) %>%
     dplyr::mutate(
       year = as.numeric(year),
       week = as.numeric(week)
-    ) |>
-    dplyr::arrange(year, week) |>
+    ) %>%
+    dplyr::arrange(year, week) %>%
     as.data.frame()
 }
 
@@ -307,7 +307,7 @@ add_cw_iso <- function(data,
 
   # add cw_iso (isoweeks) as factor levels
   all_cw_iso <- get_all_cw_iso(date_start = date_start, date_end = date_end)
-  data <- data |>
+  data <- data %>%
     dplyr::mutate(
       cw_iso = paste0(
         lubridate::isoyear(!!rlang::sym(date_var)), "-",

--- a/R/get_signals.R
+++ b/R/get_signals.R
@@ -174,12 +174,12 @@ get_signals_stratified <- function(data,
 
     # adding the NAs to also calculate signals for them
     if (any(is.na(data[, category]))) {
-      sub_data <- sub_data |>
+      sub_data <- sub_data %>%
         dplyr::mutate(
           !!rlang::sym(category) := forcats::fct_na_value_to_level(!!rlang::sym(category), level = "NA")
         )
     }
-    sub_data <- sub_data |>
+    sub_data <- sub_data %>%
       # filter the data
       filter_by_date(date_var = date_var, date_start = date_start, date_end = date_end) %>%
       # aggregate data
@@ -348,7 +348,7 @@ get_signals <- function(data,
     }
   }
 
-  data <- data |>
+  data <- data %>%
     add_cw_iso(date_start = date_start, date_end = date_end, date_var = date_var)
 
 
@@ -510,8 +510,8 @@ pad_signals <- function(data,
     unique(signals$category)[!is.na(unique(signals$category))]
   }
 
-  # data_signals <- signals |>
-  #   dplyr::filter(!is.na(alarms)) |>
+  # data_signals <- signals %>%
+  #   dplyr::filter(!is.na(alarms)) %>%
   #   dplyr::select(year, week, category, stratum, upperbound_pad = upperbound, expected_pad = expected)
 
 
@@ -523,7 +523,7 @@ pad_signals <- function(data,
 
   cutoff_date <- max(data$date_report, na.rm = TRUE) - lubridate::weeks(number_of_weeks)
 
-  data_no_signals <- data |>
+  data_no_signals <- data %>%
     dplyr::filter(date_report <= cutoff_date)
 
   available_thresholds <- c(26, 20, 14, 8, 2)

--- a/R/glm_algorithm.R
+++ b/R/glm_algorithm.R
@@ -17,7 +17,7 @@ create_fn_data <- function(ts_length, freq = 52.25) {
   breaks[1] <- -1
   seasgroups <- cut(((1:ts_length - 1) %% freq), breaks = breaks, labels = FALSE)
 
-  data.frame(seasgroups = seasgroups) |>
+  data.frame(seasgroups = seasgroups) %>%
     dplyr::mutate(seasgroups = factor(seasgroups, levels = 1:noPeriods))
 }
 

--- a/R/plot_regional.R
+++ b/R/plot_regional.R
@@ -137,7 +137,7 @@ plot_regional <- function(shape_with_signals,
         inherit = FALSE
       )
 
-    stars_sf <- shape_with_signals |>
+    stars_sf <- shape_with_signals %>%
       dplyr::filter(any_alarms == "At least 1 signal")
     nrow_stars_before <- nrow(stars_sf)
 
@@ -147,14 +147,14 @@ plot_regional <- function(shape_with_signals,
       sf::sf_use_s2(FALSE)
 
       # calculate centre robustly
-      stars_sf <- stars_sf |>
-        sf::st_make_valid() |>
-        sf::st_centroid(of_largest_polygon = TRUE) |>
-        sf::st_collection_extract("POINT") |> # only keep points
+      stars_sf <- stars_sf %>%
+        sf::st_make_valid() %>%
+        sf::st_centroid(of_largest_polygon = TRUE) %>%
+        sf::st_collection_extract("POINT") %>% # only keep points
         dplyr::filter(!sf::st_is_empty(geometry)) # remove empty ones
 
-      stars_sf <- stars_sf |>
-        rowwise() |>
+      stars_sf <- stars_sf %>%
+        rowwise() %>%
         mutate(
           geometry = {
             pt <- geometry
@@ -175,7 +175,7 @@ plot_regional <- function(shape_with_signals,
               }
             }
           }
-        ) |>
+        ) %>%
         ungroup()
 
       sf::sf_use_s2(old_s2)

--- a/R/plot_signals_week.R
+++ b/R/plot_signals_week.R
@@ -1,7 +1,7 @@
 #' Plot in how many strata an signal was detected under the detection period
 #'
 #' Using the results of signal detection, plot a week-to-week representation of
-#' strata had higher than expected case numbers
+#' strata that had alarms
 #'
 #' @param results dataframe of a single-pathogen signal detection results for a strata category
 #' @param n_strata integer. Number of stratification levels in category. Usually determined automatically by signals_agg

--- a/R/results_table.R
+++ b/R/results_table.R
@@ -251,7 +251,7 @@ prepare_signals_table <- function(data,
   data
 }
 
-#' Builds the signal detection results table with different formating options. To get the raw data.frame containing method ald number_of_weeks as well use format = "data.frame", to obtain nicely formated tables in an interactive DataTable or as Flextable use format = "DataTable" or format = "Flextable".
+#' Builds the signal detection results table with different formatting options. To get the raw data.frame containing method ald number_of_weeks as well use format = "data.frame", to obtain nicely formatted tables in an interactive DataTable or as Flextable use format = "DataTable" or format = "Flextable".
 #'
 #' This function applies the \link{prepare_signals_table} and if format = c("DataTable","Flextable") \link{format_table} to create a nicely formated results table based on the input data frame. If format = "data.frame" \link{format_table} is not applied and the raw preprocessed signal_results are returned. It can
 #' filter the data based on the `signals_only` parameter and converts certain
@@ -383,10 +383,10 @@ prepare_signals_agg_table <- function(signals_agg) {
   signals_agg
 }
 
-#' Builds the aggregated signal detection results table with different formating options.
+#' Builds the aggregated signal detection results table with different formatting options.
 #'
 #' Prepares and formats the aggregated signal results table for one category and orders the strata by the factor levels.
-#' This function combines the preparation of the aggregated signals data.frame with the final formating of the table by applying \link{prepare_signals_agg_table} and \link{format_table}.
+#' This function combines the preparation of the aggregated signals data.frame with the final formatting of the table by applying \link{prepare_signals_agg_table} and \link{format_table}.
 #' @param signals_agg A tibble or data.frame containing aggregated signals produced from \link{aggregate_signals}(signals,number_of_weeks = 6).
 #' @param format Character specifying the output format. Must be one of:
 #'   - `"data.frame"`: A standard R data frame.

--- a/R/visualisation_deciders.R
+++ b/R/visualisation_deciders.R
@@ -12,7 +12,7 @@
 #'   - By default, this parameter is set to `get_shp_config_or_internal()`, which handles this logic dynamically.
 #' @param interactive boolean identifying whether the plot should be static or interactive
 #' @param toggle_alarms boolean identifying whether the plot should showing number of signals explicitly or only when hovering
-#' @returns a table or a plot depending on whether the matching of the NUTS IDs was fully possible, the table and plots can be interactive or not depening on the interactive parameter, can be class "ggplot" or "plotly" for plot and class "gt_tbl" or "datatables" for table
+#' @returns a table or a plot depending on whether the matching of the NUTS IDs was fully possible, the table and plots can be interactive or not depending on the interactive parameter, can be class "ggplot" or "plotly" for plot and class "gt_tbl" or "datatables" for table
 #' @examples
 #' \dontrun{
 #' signals <- input_example %>%

--- a/man/build_signals_agg_table.Rd
+++ b/man/build_signals_agg_table.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/results_table.R
 \name{build_signals_agg_table}
 \alias{build_signals_agg_table}
-\title{Builds the aggregated signal detection results table with different formating options.}
+\title{Builds the aggregated signal detection results table with different formatting options.}
 \usage{
 build_signals_agg_table(signals_agg, format = "DataTable")
 }
@@ -20,7 +20,7 @@ data.frame or DataTable or Flextable depending on `format`
 }
 \description{
 Prepares and formats the aggregated signal results table for one category and orders the strata by the factor levels.
-This function combines the preparation of the aggregated signals data.frame with the final formating of the table by applying \link{prepare_signals_agg_table} and \link{format_table}.
+This function combines the preparation of the aggregated signals data.frame with the final formatting of the table by applying \link{prepare_signals_agg_table} and \link{format_table}.
 }
 \examples{
 \dontrun{

--- a/man/build_signals_table.Rd
+++ b/man/build_signals_table.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/results_table.R
 \name{build_signals_table}
 \alias{build_signals_table}
-\title{Builds the signal detection results table with different formating options. To get the raw data.frame containing method ald number_of_weeks as well use format = "data.frame", to obtain nicely formated tables in an interactive DataTable or as Flextable use format = "DataTable" or format = "Flextable".}
+\title{Builds the signal detection results table with different formatting options. To get the raw data.frame containing method ald number_of_weeks as well use format = "data.frame", to obtain nicely formatted tables in an interactive DataTable or as Flextable use format = "DataTable" or format = "Flextable".}
 \usage{
 build_signals_table(
   signal_results,

--- a/man/create_map_or_table.Rd
+++ b/man/create_map_or_table.Rd
@@ -31,7 +31,7 @@ create_map_or_table(
 \item{toggle_alarms}{boolean identifying whether the plot should showing number of signals explicitly or only when hovering}
 }
 \value{
-a table or a plot depending on whether the matching of the NUTS IDs was fully possible, the table and plots can be interactive or not depening on the interactive parameter, can be class "ggplot" or "plotly" for plot and class "gt_tbl" or "datatables" for table
+a table or a plot depending on whether the matching of the NUTS IDs was fully possible, the table and plots can be interactive or not depending on the interactive parameter, can be class "ggplot" or "plotly" for plot and class "gt_tbl" or "datatables" for table
 }
 \description{
 Decider for creating a map or a table based on whether all NUTS_ids are found in the shapefile

--- a/man/plot_signals_per_week.Rd
+++ b/man/plot_signals_per_week.Rd
@@ -20,7 +20,7 @@ either a ggplot or plotly object
 }
 \description{
 Using the results of signal detection, plot a week-to-week representation of
-strata had higher than expected case numbers
+strata that had alarms
 }
 \examples{
 \dontrun{

--- a/vignettes/SignalDetectionTool.Rmd
+++ b/vignettes/SignalDetectionTool.Rmd
@@ -50,6 +50,7 @@ It is possible to run the app with customised settings using a yaml file. Please
 ### Data
 The input to the SDT is a linelist of infectious disease cases structured according to the format defined in `input_metadata`.
 A sample linelist (`input_example`) and its corresponding metadata specification (`input_metadata`) is available in the package as internal datasets and can be accessed using:
+
 ```{r, eval=FALSE}
 data("input_example")
 data("input_metadata")
@@ -60,6 +61,7 @@ data("input_metadata")
 To apply signal detection to your data for the most recent 6 weeks you first need to preprocess your linelist and then apply `get_signals()`. Inside `get_signals()` the linelist is aggregated to a timeseries containing weekly counts of cases.  
 To apply different signal detection methods use the parameter method. To generate stratified signals use the parameter stratification. Please have a look at the function documentation for more details. 
 This is an example for signals generated using the default parameters with FarringtonFlexible and no stratification: 
+
 ```{r}
 data_prepro <- input_example %>% preprocess_data()
 signals <- data_prepro %>% get_signals()
@@ -102,85 +104,60 @@ In this example we obtain:
 
 ### Create visualisations and tables
 
-To visualise signal detection in your data for the most recent `number_of_weeks`, you first need to preprocess your linelist and then apply `get_signals()`. For some visualisations you then have to aggregate data and need to specify a shapefile to use. In the final step you can apply a function to either create a plot or a table.
+To visualise signal detection in your data for the most recent `number_of_weeks`, you first need to preprocess your linelist and then apply `get_signals()`. To display aggregated signal detection results, first aggregate the signals. In the final step, apply a function to generate either a plot or a table.
 
-The following example shows how to visualise the timeseries of detected signals using the default parameters of FarringtonFlexible without stratification.`plot_time_series()`:
+The following example shows how to visualise the time series of detected signals using the default parameters of FarringtonFlexible without stratification in `plot_time_series()`:
+
 ```{r}
 data_prepro <- input_example %>% preprocess_data()
 signals <- data_prepro %>% get_signals()
-time_series <- signals %>% plot_time_series()
+signals_time_series <- signals %>% plot_time_series()
 ```
 
-In the timeseries visualisation, the detection period is shaded in blue. The expectation is shown as a black line. The threshold is indicated by a blue line. Weekly case counts are displayed as bars. A signal is generated for a given week when the number of cases exceeds the threshold.
-
-To create a table with different formatting options you can use `build_signals_table()`. This is an example for creating a DataTable using age_group as `stratum` and default options: 
-```{r}
-data_prepro <- input_example %>% preprocess_data()
-signals <- data_prepro %>% get_signals(stratification = c("age_group"), 
-                                       number_of_weeks = 6
-                                       )
-build_signals_table(signals)
-```
-
-To create a non-interactive map you have to use aggregated signals and an appropriate shapefile. Both have to be specified in `create_map_or_table()` and interactive should be set to FALSE. `plot_regional()` is used by the function. This is an example for visualising the specified data using "county" as `stratum` as a map because the matching of the NUTS IDs is fully possible. Otherwise a table would be created. 
-```{r}
-data_prepro <- input_example %>% preprocess_data() 
-signals <- data_prepro %>% get_signals(stratification = c("county"))
-signals_agg <- signals %>% aggregate_signals(number_of_weeks = 6)
-create_map_or_table(signals_agg, 
-                    input_example, 
-                    "county", 
-                    nuts_shp, 
-                    interactive = FALSE
-                    )
-```
-
-In the non-interactive map visualisation, the number of cases per region is represented by the shade of blue, with darker shades indicating higher case counts. Regions without signals are shown with a black border. If at least one signal occurs in a region, the border is coloured red and the number of signals is displayed as a label within the region.
-
-To create an interactive or a non-interactive barplot or a table you have to use aggregated signals in `create_barplot_or_table()`. Depending on the number of unique levels to visualise it is decided whether a barplot or a table is shown. If you want to visualise a barplot you can use `plot_barchart()` following the same steps. This is an example for visualising the specified data using "age group" as `stratum` and for the non-interactive plot using `create_barplot_or_table()`:
-```{r}
-data_prepro <- input_example %>% preprocess_data() 
-signals <- data_prepro %>% get_signals(stratification = c("age_group"))
-signals_agg <- signals %>% aggregate_signals(number_of_weeks = 6)
-
-# Choose one of the two functions: 
-create_barplot_or_table(signals_agg, "age_group", 
-                        interactive = FALSE
-                        )
-plot_barchart(signals_agg)
-```
-
-In the non-interactive barplot visualisation, the number of cases is represented by the height of the bars. If no signal occurs in a given stratum, the bar has no border. If at least one signal is detected, the bar is outlined in red. For non-interactive plots, the number of signals is additionally displayed as a label above the bar.
-
-To create an interactive or a non-interactive 100% stacked barplot showing a week-to-week representation of strata levels that had alarms you have to use signal data and specify the number of stratification levels in `plot_signals_per_week()`. This is an example for visualising the specified data using "county" as `stratum` with 9 levels for the non-interactive plot:
-```{r}
-data_prepro <- preprocess_data(input_example)
-signals <- get_signals(data_prepro, 
-                       stratification = "county"
-                       )
-n.strata <- 9
-plot_signals_per_week(signals, 
-                      n_strata = n.strata
-                      )
-```
-
-In the non-interactive 100% stacked barplot visualisation, the proportion of levels with alarms per week is represented by the height of the red segment of each bar. If no signal occurs in a given week, the bar is shown entirely in grey.
+In the time series visualisation, the detection period is shaded in blue. The expectation is shown as a black line. The threshold is indicated by a blue line. Weekly case counts are displayed as bars. A signal is generated for a given week when the number of cases exceeds the threshold.
 
 To create a bar plot grouping the "age_group" by another `stratum` use preprocessed data in `plot_agegroup_by()`. This is an example using the `stratum` "county": 
+
 ```{r}
 data_prepro <- input_example %>% preprocess_data()
-plot_agegroup_by(df = data_prepro,
-                 age_group_col = "age_group", 
-                 by_col = "county"
-                 )
+plot_agegroup <- data_prepro %>% plot_agegroup_by(
+  age_group_col = "age_group", 
+  by_col = "county"
+  )
 ```
 
-In the bar plot the height of a bar represents the case count for the specified "county" and "age group". 
+In the bar plot, bar height represents the case count for the specified "county" and "age group".
+
+To create a signals detection results table with different formatting options you can use `build_signals_table()`. This is an example for creating a DataTable using age_group as `stratum` and default options: 
+
+```{r}
+data_prepro <- input_example %>% preprocess_data()
+signals <- data_prepro %>% get_signals(
+  stratification = c("age_group"), 
+  number_of_weeks = 6
+  )
+signals_table <- signals %>% build_signals_table()
+```
+
+To create an aggregated signal detection results table with different formatting options you can use `build_signals_agg_table()`. This is an example for creating a DataTable using age_group as `stratum` and default options: 
+
+```{r}
+data_prepro <- input_example %>% preprocess_data()
+signals <- data_prepro %>% get_signals(
+  stratification = c("age_group"), 
+  number_of_weeks = 6
+  )
+agg_signals <- signals %>%  aggregate_signals(number_of_weeks = 6) 
+agg_signals %>% build_signals_agg_table()
+```
+
+In the table, rows with a signal are highlighted in red.
 
 ### Run the report
 #### Single-pathogen reporting
 
 You can directly generate an HTML or Word report containing signal results and visualizations using `run_report()`. Simply pass your surveillance linelist—structured according to the format defined in `input_metadata`—to `run_report()`. The data will be preprocessed automatically within the function. The following code chunk generates a Word report using EARS without any stratification (default) for the past six weeks (default):
+
 ```{r, eval=FALSE}
 run_report(input_example,
   report_format = "DOCX",
@@ -189,6 +166,7 @@ run_report(input_example,
 ```
 
 This generates an HTML report (default) with stratification by age group, county and sex for the last 2 weeks using FarringtonFlexible (default):
+
 ```{r, eval=FALSE}
 run_report(input_example,
   strata = c("age_group", "county", "sex"),
@@ -211,6 +189,7 @@ data("input_example_multipathogen")
 ```
 
 To run an HTML report with the EARS algorithm and stratification by age_group and county for all pathogens in the line list you can run: 
+
 ```{r, eval=FALSE}
 run_report(input_example_multipathogen,
   strata = c("age_group", "county"),

--- a/vignettes/SignalDetectionTool.Rmd
+++ b/vignettes/SignalDetectionTool.Rmd
@@ -55,12 +55,11 @@ data("input_example")
 data("input_metadata")
 ```
 
-
 ### Applying signal detection
 
 To apply signal detection to your data for the most recent 6 weeks you first need to preprocess your linelist and then apply `get_signals()`. Inside `get_signals()` the linelist is aggregated to a timeseries containing weekly counts of cases.  
 To apply different signal detection methods use the parameter method. To generate stratified signals use the parameter stratification. Please have a look at the function documentation for more details. 
-This is an example for signals generated using the default paramters with FarringtonFlexible and no stratification: 
+This is an example for signals generated using the default parameters with FarringtonFlexible and no stratification: 
 ```{r}
 data_prepro <- input_example %>% preprocess_data()
 signals <- data_prepro %>% get_signals()
@@ -101,14 +100,85 @@ In this example we obtain:
 "90–94", "95–99", "100–104", "105–109" for rows with `category == "age_group"`.  For rows with `category == "county"` the values of `stratum` are "Burgenland", "Kärnten", "Niederösterreich", "Oberösterreich", "Salzburg", 
 "Steiermark", "Tirol", "Vorarlberg", "Wien".
 
-
 ### Create visualisations and tables
 
-Coming soon...
+To visualise signal detection in your data for the most recent `number_of_weeks`, you first need to preprocess your linelist and then apply `get_signals()`. For some visualisations you then have to aggregate data and need to specify a shapefile to use. In the final step you can apply a function to either create a plot or a table.
+
+The following example shows how to visualise the timeseries of detected signals using the default parameters of FarringtonFlexible without stratification.`plot_time_series()`:
+```{r}
+data_prepro <- input_example %>% preprocess_data()
+signals <- data_prepro %>% get_signals()
+time_series <- signals %>% plot_time_series()
+```
+
+In the timeseries visualisation, the detection period is shaded in blue. The expectation is shown as a black line. The threshold is indicated by a blue line. Weekly case counts are displayed as bars. A signal is generated for a given week when the number of cases exceeds the threshold.
+
+To create a table with different formatting options you can use `build_signals_table()`. This is an example for creating a DataTable using age_group as `stratum` and default options: 
+```{r}
+data_prepro <- input_example %>% preprocess_data()
+signals <- data_prepro %>% get_signals(stratification = c("age_group"), 
+                                       number_of_weeks = 6
+                                       )
+build_signals_table(signals)
+```
+
+To create a non-interactive map you have to use aggregated signals and an appropriate shapefile. Both have to be specified in `create_map_or_table()` and interactive should be set to FALSE. `plot_regional()` is used by the function. This is an example for visualising the specified data using "county" as `stratum` as a map because the matching of the NUTS IDs is fully possible. Otherwise a table would be created. 
+```{r}
+data_prepro <- input_example %>% preprocess_data() 
+signals <- data_prepro %>% get_signals(stratification = c("county"))
+signals_agg <- signals %>% aggregate_signals(number_of_weeks = 6)
+create_map_or_table(signals_agg, 
+                    input_example, 
+                    "county", 
+                    nuts_shp, 
+                    interactive = FALSE
+                    )
+```
+
+In the non-interactive map visualisation, the number of cases per region is represented by the shade of blue, with darker shades indicating higher case counts. Regions without signals are shown with a black border. If at least one signal occurs in a region, the border is coloured red and the number of signals is displayed as a label within the region.
+
+To create an interactive or a non-interactive barplot or a table you have to use aggregated signals in `create_barplot_or_table()`. Depending on the number of unique levels to visualise it is decided whether a barplot or a table is shown. If you want to visualise a barplot you can use `plot_barchart()` following the same steps. This is an example for visualising the specified data using "age group" as `stratum` and for the non-interactive plot using `create_barplot_or_table()`:
+```{r}
+data_prepro <- input_example %>% preprocess_data() 
+signals <- data_prepro %>% get_signals(stratification = c("age_group"))
+signals_agg <- signals %>% aggregate_signals(number_of_weeks = 6)
+
+# Choose one of the two functions: 
+create_barplot_or_table(signals_agg, "age_group", 
+                        interactive = FALSE
+                        )
+plot_barchart(signals_agg)
+```
+
+In the non-interactive barplot visualisation, the number of cases is represented by the height of the bars. If no signal occurs in a given stratum, the bar has no border. If at least one signal is detected, the bar is outlined in red. For non-interactive plots, the number of signals is additionally displayed as a label above the bar.
+
+To create an interactive or a non-interactive 100% stacked barplot showing a week-to-week representation of strata levels that had alarms you have to use signal data and specify the number of stratification levels in `plot_signals_per_week()`. This is an example for visualising the specified data using "county" as `stratum` with 9 levels for the non-interactive plot:
+```{r}
+data_prepro <- preprocess_data(input_example)
+signals <- get_signals(data_prepro, 
+                       stratification = "county"
+                       )
+n.strata <- 9
+plot_signals_per_week(signals, 
+                      n_strata = n.strata
+                      )
+```
+
+In the non-interactive 100% stacked barplot visualisation, the proportion of levels with alarms per week is represented by the height of the red segment of each bar. If no signal occurs in a given week, the bar is shown entirely in grey.
+
+To create a bar plot grouping the "age_group" by another `stratum` use preprocessed data in `plot_agegroup_by()`. This is an example using the `stratum` "county": 
+```{r}
+data_prepro <- input_example %>% preprocess_data()
+plot_agegroup_by(df = data_prepro,
+                 age_group_col = "age_group", 
+                 by_col = "county"
+                 )
+```
+
+In the bar plot the height of a bar represents the case count for the specified "county" and "age group". 
 
 ### Run the report
 #### Single-pathogen reporting
-
 
 You can directly generate an HTML or Word report containing signal results and visualizations using `run_report()`. Simply pass your surveillance linelist—structured according to the format defined in `input_metadata`—to `run_report()`. The data will be preprocessed automatically within the function. The following code chunk generates a Word report using EARS without any stratification (default) for the past six weeks (default):
 ```{r, eval=FALSE}

--- a/vignettes/SignalDetectionTool.Rmd
+++ b/vignettes/SignalDetectionTool.Rmd
@@ -116,37 +116,38 @@ In the timeseries visualisation, the detection period is shaded in blue. The exp
 To create a table with different formatting options you can use `build_signals_table()`. This is an example for creating a DataTable using age_group as `stratum` and default options: 
 ```{r}
 data_prepro <- input_example %>% preprocess_data()
-signals <- data_prepro %>% get_signals(stratification = c("age_group"), 
-                                       number_of_weeks = 6
-                                       )
+signals <- data_prepro %>% get_signals(
+  stratification = c("age_group"),
+  number_of_weeks = 6
+)
 build_signals_table(signals)
 ```
 
 To create a non-interactive map you have to use aggregated signals and an appropriate shapefile. Both have to be specified in `create_map_or_table()` and interactive should be set to FALSE. `plot_regional()` is used by the function. This is an example for visualising the specified data using "county" as `stratum` as a map because the matching of the NUTS IDs is fully possible. Otherwise a table would be created. 
 ```{r}
-data_prepro <- input_example %>% preprocess_data() 
+data_prepro <- input_example %>% preprocess_data()
 signals <- data_prepro %>% get_signals(stratification = c("county"))
 signals_agg <- signals %>% aggregate_signals(number_of_weeks = 6)
-create_map_or_table(signals_agg, 
-                    input_example, 
-                    "county", 
-                    nuts_shp, 
-                    interactive = FALSE
-                    )
+create_map_or_table(signals_agg,
+  input_example,
+  "county",
+  nuts_shp,
+  interactive = FALSE
+)
 ```
 
 In the non-interactive map visualisation, the number of cases per region is represented by the shade of blue, with darker shades indicating higher case counts. Regions without signals are shown with a black border. If at least one signal occurs in a region, the border is coloured red and the number of signals is displayed as a label within the region.
 
 To create an interactive or a non-interactive barplot or a table you have to use aggregated signals in `create_barplot_or_table()`. Depending on the number of unique levels to visualise it is decided whether a barplot or a table is shown. If you want to visualise a barplot you can use `plot_barchart()` following the same steps. This is an example for visualising the specified data using "age group" as `stratum` and for the non-interactive plot using `create_barplot_or_table()`:
 ```{r}
-data_prepro <- input_example %>% preprocess_data() 
+data_prepro <- input_example %>% preprocess_data()
 signals <- data_prepro %>% get_signals(stratification = c("age_group"))
 signals_agg <- signals %>% aggregate_signals(number_of_weeks = 6)
 
-# Choose one of the two functions: 
-create_barplot_or_table(signals_agg, "age_group", 
-                        interactive = FALSE
-                        )
+# Choose one of the two functions:
+create_barplot_or_table(signals_agg, "age_group",
+  interactive = FALSE
+)
 plot_barchart(signals_agg)
 ```
 
@@ -155,13 +156,13 @@ In the non-interactive barplot visualisation, the number of cases is represented
 To create an interactive or a non-interactive 100% stacked barplot showing a week-to-week representation of strata levels that had alarms you have to use signal data and specify the number of stratification levels in `plot_signals_per_week()`. This is an example for visualising the specified data using "county" as `stratum` with 9 levels for the non-interactive plot:
 ```{r}
 data_prepro <- preprocess_data(input_example)
-signals <- get_signals(data_prepro, 
-                       stratification = "county"
-                       )
+signals <- get_signals(data_prepro,
+  stratification = "county"
+)
 n.strata <- 9
-plot_signals_per_week(signals, 
-                      n_strata = n.strata
-                      )
+plot_signals_per_week(signals,
+  n_strata = n.strata
+)
 ```
 
 In the non-interactive 100% stacked barplot visualisation, the proportion of levels with alarms per week is represented by the height of the red segment of each bar. If no signal occurs in a given week, the bar is shown entirely in grey.
@@ -169,10 +170,11 @@ In the non-interactive 100% stacked barplot visualisation, the proportion of lev
 To create a bar plot grouping the "age_group" by another `stratum` use preprocessed data in `plot_agegroup_by()`. This is an example using the `stratum` "county": 
 ```{r}
 data_prepro <- input_example %>% preprocess_data()
-plot_agegroup_by(df = data_prepro,
-                 age_group_col = "age_group", 
-                 by_col = "county"
-                 )
+plot_agegroup_by(
+  df = data_prepro,
+  age_group_col = "age_group",
+  by_col = "county"
+)
 ```
 
 In the bar plot the height of a bar represents the case count for the specified "county" and "age group". 


### PR DESCRIPTION
This fix replaces all instances of the r-native pipe operator "|>" by the magrittr-pipe "%>%".  The support of the stated R-version 4.0.2 is continued.