### PR TITLE
replace R-native pipe operators

### DIFF
--- a/R/data_processing.R
+++ b/R/data_processing.R
@@ -167,13 +167,13 @@ aggregate_data <- function(data,
       dplyr::left_join(data_outbreak_agg, by = c("cw_iso", group)) %>%
       dplyr::mutate(cases_in_outbreak = dplyr::if_else(is.na(cases_in_outbreak), 0, cases_in_outbreak))
   }
-  data_agg |>
-    tidyr::separate_wider_delim(cw_iso, delim = "-", names = c("year", "week")) |>
+  data_agg %>%
+    tidyr::separate_wider_delim(cw_iso, delim = "-", names = c("year", "week")) %>%
     dplyr::mutate(
       year = as.numeric(year),
       week = as.numeric(week)
-    ) |>
-    dplyr::arrange(year, week) |>
+    ) %>%
+    dplyr::arrange(year, week) %>%
     as.data.frame()
 }
 
@@ -307,7 +307,7 @@ add_cw_iso <- function(data,
 
   # add cw_iso (isoweeks) as factor levels
   all_cw_iso <- get_all_cw_iso(date_start = date_start, date_end = date_end)
-  data <- data |>
+  data <- data %>%
     dplyr::mutate(
       cw_iso = paste0(
         lubridate::isoyear(!!rlang::sym(date_var)), "-",

--- a/R/get_signals.R
+++ b/R/get_signals.R
@@ -174,12 +174,12 @@ get_signals_stratified <- function(data,
 
     # adding the NAs to also calculate signals for them
     if (any(is.na(data[, category]))) {
-      sub_data <- sub_data |>
+      sub_data <- sub_data %>%
         dplyr::mutate(
           !!rlang::sym(category) := forcats::fct_na_value_to_level(!!rlang::sym(category), level = "NA")
         )
     }
-    sub_data <- sub_data |>
+    sub_data <- sub_data %>%
       # filter the data
       filter_by_date(date_var = date_var, date_start = date_start, date_end = date_end) %>%
       # aggregate data
@@ -348,7 +348,7 @@ get_signals <- function(data,
     }
   }
 
-  data <- data |>
+  data <- data %>%
     add_cw_iso(date_start = date_start, date_end = date_end, date_var = date_var)
 
 
@@ -510,8 +510,8 @@ pad_signals <- function(data,
     unique(signals$category)[!is.na(unique(signals$category))]
   }
 
-  # data_signals <- signals |>
-  #   dplyr::filter(!is.na(alarms)) |>
+  # data_signals <- signals %>%
+  #   dplyr::filter(!is.na(alarms)) %>%
   #   dplyr::select(year, week, category, stratum, upperbound_pad = upperbound, expected_pad = expected)
 
 
@@ -523,7 +523,7 @@ pad_signals <- function(data,
 
   cutoff_date <- max(data$date_report, na.rm = TRUE) - lubridate::weeks(number_of_weeks)
 
-  data_no_signals <- data |>
+  data_no_signals <- data %>%
     dplyr::filter(date_report <= cutoff_date)
 
   available_thresholds <- c(26, 20, 14, 8, 2)

--- a/R/glm_algorithm.R
+++ b/R/glm_algorithm.R
@@ -17,7 +17,7 @@ create_fn_data <- function(ts_length, freq = 52.25) {
   breaks[1] <- -1
   seasgroups <- cut(((1:ts_length - 1) %% freq), breaks = breaks, labels = FALSE)
 
-  data.frame(seasgroups = seasgroups) |>
+  data.frame(seasgroups = seasgroups) %>%
     dplyr::mutate(seasgroups = factor(seasgroups, levels = 1:noPeriods))
 }
 

--- a/R/plot_regional.R
+++ b/R/plot_regional.R
@@ -137,7 +137,7 @@ plot_regional <- function(shape_with_signals,
         inherit = FALSE
       )
 
-    stars_sf <- shape_with_signals  %>%
+    stars_sf <- shape_with_signals %>%
       dplyr::filter(any_alarms == "At least 1 signal")
     nrow_stars_before <- nrow(stars_sf)
 

--- a/R/plot_regional.R
+++ b/R/plot_regional.R
@@ -137,7 +137,7 @@ plot_regional <- function(shape_with_signals,
         inherit = FALSE
       )
 
-    stars_sf <- shape_with_signals |>
+    stars_sf <- shape_with_signals  %>%
       dplyr::filter(any_alarms == "At least 1 signal")
     nrow_stars_before <- nrow(stars_sf)
 
@@ -147,14 +147,14 @@ plot_regional <- function(shape_with_signals,
       sf::sf_use_s2(FALSE)
 
       # calculate centre robustly
-      stars_sf <- stars_sf |>
-        sf::st_make_valid() |>
-        sf::st_centroid(of_largest_polygon = TRUE) |>
-        sf::st_collection_extract("POINT") |> # only keep points
+      stars_sf <- stars_sf %>%
+        sf::st_make_valid() %>%
+        sf::st_centroid(of_largest_polygon = TRUE) %>%
+        sf::st_collection_extract("POINT") %>% # only keep points
         dplyr::filter(!sf::st_is_empty(geometry)) # remove empty ones
 
-      stars_sf <- stars_sf |>
-        rowwise() |>
+      stars_sf <- stars_sf %>%
+        rowwise() %>%
         mutate(
           geometry = {
             pt <- geometry
@@ -175,7 +175,7 @@ plot_regional <- function(shape_with_signals,
               }
             }
           }
-        ) |>
+        ) %>%
         ungroup()
 
       sf::sf_use_s2(old_s2)


### PR DESCRIPTION
This fix replaces all instances of the r-native pipe operator "|>" by the magrittr-pipe "%>%". The support of the stated R-version 4.0.2 is continued.