### PR TITLE
Fixing threshold and expectation in historic data when using a date extension

### DIFF
--- a/R/data_processing.R
+++ b/R/data_processing.R
@@ -132,11 +132,22 @@ aggregate_data <- function(data,
     checkmate::check_date(lubridate::date(date_end)),
     combine = "or"
   )
+
   checkmate::assert(
     checkmate::check_null(date_ext),
-    checkmate::check_date(lubridate::date(date_ext)),
+    checkmate::check_date(
+      lubridate::date(date_ext),
+      lower = max(lubridate::date(data[[date_var]]), na.rm = TRUE)
+    ),
     combine = "or"
   )
+
+  if (!is.null(date_end) && !is.null(date_ext)) {
+    checkmate::assert_true(
+      lubridate::date(date_ext) >= lubridate::date(date_end),
+      .var.name = "date_ext must be >= date_end"
+    )
+  }
 
   if (!is.null(date_ext)) {
     if (is.null(date_start)) { # TODO check when is this really NULL

--- a/R/get_signals.R
+++ b/R/get_signals.R
@@ -627,14 +627,13 @@ pad_signals <- function(data,
   }
   } else if(!is.null(date_ext)){
 
-    # also look at filters?
     if ((date_ext - lubridate::weeks(number_of_weeks)) < max(data[[date_var]], na.rm = TRUE)) {
       diff_weeks <- as.numeric(
         lubridate::interval(date_ext - lubridate::weeks(number_of_weeks),
                  max(data[[date_var]], na.rm = TRUE)) / lubridate::days(7)
       )
       diff_weeks <- floor(diff_weeks)
-      cutoff_date <- max(data[[date_var]], na.rm = TRUE) - lubridate::weeks(number_of_weeks) + lubridate::weeks(diff_weeks) # to do: round correctly
+      cutoff_date <- max(data[[date_var]], na.rm = TRUE) - lubridate::weeks(number_of_weeks) + lubridate::weeks(diff_weeks)
 
       data_no_signals <- data %>%
         dplyr::filter(.data[[date_var]] <= cutoff_date)
@@ -656,7 +655,7 @@ pad_signals <- function(data,
         break
       }
     }
-    } else { # To do; is it rational to use the historic threshold option here?
+    } else {
         data_no_signals <- data
 
          available_thresholds <- c(26, 20, 14, 8, 2)
@@ -681,8 +680,6 @@ pad_signals <- function(data,
 
   result_padding_unstratified <- signals_timeopt %>%
     dplyr::select(year, week, category, stratum, upperbound_pad = upperbound, expected_pad = expected)
-
-  # TO DO: STRATIFICATION
 
   # preparing dataset with padding
   if (is.null(stratification)) {

--- a/R/get_signals.R
+++ b/R/get_signals.R
@@ -214,6 +214,12 @@ get_signals_stratified <- function(data,
       # aggregate data
       aggregate_data(date_var = date_var, date_start = date_start, date_end = date_end, date_ext = date_ext, group = category)
 
+    # add extension date information if available
+    if(!is.null(date_ext)){
+      sub_data <- sub_data %>%
+        dplyr::mutate(extension_date = date_ext)
+    }
+
     split_list <- sub_data %>%
       dplyr::group_split(!!rlang::sym(category), .keep = FALSE)
     strata <- levels(sub_data[, category])
@@ -351,6 +357,11 @@ get_signals <- function(data,
     combine = "or"
   )
   checkmate::assert(
+    checkmate::check_null(date_ext),
+    checkmate::check_date(lubridate::date(date_ext)),
+    combine = "or"
+  )
+  checkmate::assert(
     checkmate::check_character(date_var, len = 1, pattern = "date")
   )
 
@@ -445,6 +456,11 @@ get_signals <- function(data,
       )
   }
 
+  # add extension date information if available
+  if(!is.null(date_ext)){
+    results <- results %>%
+      dplyr::mutate(extension_date = date_ext)
+  }
 
   return(results)
 }
@@ -568,6 +584,12 @@ pad_signals <- function(data,
   number_of_weeks <- unique(signals$number_of_weeks)
   method <- unique(signals$method)
 
+  date_ext <- if ("extension_date" %in% names(signals)) {
+    unique(signals$extension_date)
+  } else {
+    NULL
+  }
+
   if (grepl("farrington", method)) {
     alpha_upper <- unique(signals$alpha_upper)
   } else {
@@ -576,7 +598,9 @@ pad_signals <- function(data,
 
   stopifnot(length(number_of_weeks) == 1)
   stopifnot(length(method) == 1)
+  stopifnot(is.null(date_ext) || length(date_ext) == 1)
 
+  if (is.null(date_ext)){
   cutoff_date <- max(data$date_report, na.rm = TRUE) - lubridate::weeks(number_of_weeks)
 
   data_no_signals <- data %>%
@@ -591,13 +615,62 @@ pad_signals <- function(data,
       data_no_signals,
       method = method,
       number_of_weeks = timeopt + number_of_weeks,
-      alpha_upper = alpha_upper
+      alpha_upper = alpha_upper,
+      date_ext = date_ext
     )
 
     if (!is.null(signals_timeopt)) {
       break
     }
   }
+  } #else if(!is.null(date_ext)){
+    #
+    # # also look at filters?
+    # if ((date_ext - lubridate::weeks(number_of_weeks)) < max(data$date_report, na.rm = TRUE)) {
+    #   cutoff_date <- date_ext - lubridate::weeks(number_of_weeks)
+    #
+    #   data_no_signals <- data %>%
+    #     dplyr::filter(date_report <= cutoff_date)
+    #
+    # available_thresholds <- c(26, 20, 14, 8, 2)
+    #
+    # for (timeopt in available_thresholds) {
+    #   max_time_opt <- timeopt
+    #
+    #   signals_timeopt <- SignalDetectionTool::get_signals(
+    #     data_no_signals,
+    #     method = method,
+    #     number_of_weeks = timeopt + number_of_weeks,
+    #     alpha_upper = alpha_upper,
+    #     date_ext = date_ext - lubridate::weeks(number_of_weeks)
+    #   )
+    #
+    #   if (!is.null(signals_timeopt)) {
+    #     break
+    #   }
+    # }
+    # } else {
+    #     data_no_signals <- data
+    #
+    #      available_thresholds <- c(26, 20, 14, 8, 2)
+    #
+    #     for (timeopt in available_thresholds) {
+    #       max_time_opt <- timeopt
+    #
+    #       signals_timeopt <- SignalDetectionTool::get_signals(
+    #         data_no_signals,
+    #         method = method,
+    #         number_of_weeks = timeopt + number_of_weeks,
+    #         alpha_upper = alpha_upper,
+    #         date_ext = date_ext - lubridate::weeks(number_of_weeks)
+    #       )
+    #
+    #       if (!is.null(signals_timeopt)) {
+    #         break
+    #       }
+    #     }
+    #   }
+    # }
 
   result_padding_unstratified <- signals_timeopt %>%
     dplyr::select(year, week, category, stratum, upperbound_pad = upperbound, expected_pad = expected)
@@ -612,7 +685,8 @@ pad_signals <- function(data,
       date_var = "date_report",
       stratification = stratification,
       number_of_weeks = max_time_opt + number_of_weeks,
-      alpha_upper = alpha_upper
+      alpha_upper = alpha_upper,
+      date_ext = date_ext
     ) %>%
       dplyr::select(year, week, upperbound_pad = upperbound, expected_pad = expected, category, stratum) %>%
       dplyr::group_by(category, stratum) %>%

--- a/R/get_signals.R
+++ b/R/get_signals.R
@@ -215,7 +215,7 @@ get_signals_stratified <- function(data,
       aggregate_data(date_var = date_var, date_start = date_start, date_end = date_end, date_ext = date_ext, group = category)
 
     # add extension date information if available
-    if(!is.null(date_ext)){
+    if (!is.null(date_ext)) {
       sub_data <- sub_data %>%
         dplyr::mutate(extension_date = date_ext)
     }
@@ -457,7 +457,7 @@ get_signals <- function(data,
   }
 
   # add extension date information if available
-  if(!is.null(date_ext)){
+  if (!is.null(date_ext)) {
     results <- results %>%
       dplyr::mutate(extension_date = date_ext)
   }
@@ -602,41 +602,11 @@ pad_signals <- function(data,
   stopifnot(length(method) == 1)
   stopifnot(is.null(date_ext) || length(date_ext) == 1)
 
-  if (is.null(date_ext)){
-  cutoff_date <- max(data[[date_var]], na.rm = TRUE) - lubridate::weeks(number_of_weeks)
+  if (is.null(date_ext)) {
+    cutoff_date <- max(data[[date_var]], na.rm = TRUE) - lubridate::weeks(number_of_weeks)
 
-  data_no_signals <- data %>%
-    dplyr::filter(.data[[date_var]] <= cutoff_date)
-
-  available_thresholds <- c(26, 20, 14, 8, 2)
-
-  for (timeopt in available_thresholds) {
-    max_time_opt <- timeopt
-
-    signals_timeopt <- SignalDetectionTool::get_signals(
-      data_no_signals,
-      method = method,
-      number_of_weeks = timeopt + number_of_weeks,
-      alpha_upper = alpha_upper,
-      date_ext = date_ext
-    )
-
-    if (!is.null(signals_timeopt)) {
-      break
-    }
-  }
-  } else if(!is.null(date_ext)){
-
-    if ((date_ext - lubridate::weeks(number_of_weeks)) < max(data[[date_var]], na.rm = TRUE)) {
-      diff_weeks <- as.numeric(
-        lubridate::interval(date_ext - lubridate::weeks(number_of_weeks),
-                 max(data[[date_var]], na.rm = TRUE)) / lubridate::days(7)
-      )
-      diff_weeks <- floor(diff_weeks)
-      cutoff_date <- max(data[[date_var]], na.rm = TRUE) - lubridate::weeks(number_of_weeks) + lubridate::weeks(diff_weeks)
-
-      data_no_signals <- data %>%
-        dplyr::filter(.data[[date_var]] <= cutoff_date)
+    data_no_signals <- data %>%
+      dplyr::filter(.data[[date_var]] <= cutoff_date)
 
     available_thresholds <- c(26, 20, 14, 8, 2)
 
@@ -648,35 +618,66 @@ pad_signals <- function(data,
         method = method,
         number_of_weeks = timeopt + number_of_weeks,
         alpha_upper = alpha_upper,
-        date_ext = date_ext - lubridate::weeks(number_of_weeks)
+        date_ext = date_ext
       )
 
       if (!is.null(signals_timeopt)) {
         break
       }
     }
+  } else if (!is.null(date_ext)) {
+    if ((date_ext - lubridate::weeks(number_of_weeks)) < max(data[[date_var]], na.rm = TRUE)) {
+      diff_weeks <- as.numeric(
+        lubridate::interval(
+          date_ext - lubridate::weeks(number_of_weeks),
+          max(data[[date_var]], na.rm = TRUE)
+        ) / lubridate::days(7)
+      )
+      diff_weeks <- floor(diff_weeks)
+      cutoff_date <- max(data[[date_var]], na.rm = TRUE) - lubridate::weeks(number_of_weeks) + lubridate::weeks(diff_weeks)
+
+      data_no_signals <- data %>%
+        dplyr::filter(.data[[date_var]] <= cutoff_date)
+
+      available_thresholds <- c(26, 20, 14, 8, 2)
+
+      for (timeopt in available_thresholds) {
+        max_time_opt <- timeopt
+
+        signals_timeopt <- SignalDetectionTool::get_signals(
+          data_no_signals,
+          method = method,
+          number_of_weeks = timeopt + number_of_weeks,
+          alpha_upper = alpha_upper,
+          date_ext = date_ext - lubridate::weeks(number_of_weeks)
+        )
+
+        if (!is.null(signals_timeopt)) {
+          break
+        }
+      }
     } else {
-        data_no_signals <- data
+      data_no_signals <- data
 
-         available_thresholds <- c(26, 20, 14, 8, 2)
+      available_thresholds <- c(26, 20, 14, 8, 2)
 
-        for (timeopt in available_thresholds) {
-          max_time_opt <- timeopt
+      for (timeopt in available_thresholds) {
+        max_time_opt <- timeopt
 
-          signals_timeopt <- SignalDetectionTool::get_signals(
-            data_no_signals,
-            method = method,
-            number_of_weeks = timeopt + number_of_weeks,
-            alpha_upper = alpha_upper,
-            date_ext = date_ext - lubridate::weeks(number_of_weeks)
-          )
+        signals_timeopt <- SignalDetectionTool::get_signals(
+          data_no_signals,
+          method = method,
+          number_of_weeks = timeopt + number_of_weeks,
+          alpha_upper = alpha_upper,
+          date_ext = date_ext - lubridate::weeks(number_of_weeks)
+        )
 
-          if (!is.null(signals_timeopt)) {
-            break
-          }
+        if (!is.null(signals_timeopt)) {
+          break
         }
       }
     }
+  }
 
   result_padding_unstratified <- signals_timeopt %>%
     dplyr::select(year, week, category, stratum, upperbound_pad = upperbound, expected_pad = expected)

--- a/R/get_signals.R
+++ b/R/get_signals.R
@@ -584,10 +584,10 @@ pad_signals <- function(data,
   number_of_weeks <- unique(signals$number_of_weeks)
   method <- unique(signals$method)
 
-  date_ext <- if ("extension_date" %in% names(signals)) {
-    unique(signals$extension_date)
+  if ("extension_date" %in% names(signals)) {
+    date_ext <- unique(signals$extension_date)
   } else {
-    NULL
+    date_ext <- NULL
   }
 
   if (grepl("farrington", method)) {
@@ -623,57 +623,63 @@ pad_signals <- function(data,
       break
     }
   }
-  } #else if(!is.null(date_ext)){
-    #
-    # # also look at filters?
-    # if ((date_ext - lubridate::weeks(number_of_weeks)) < max(data$date_report, na.rm = TRUE)) {
-    #   cutoff_date <- date_ext - lubridate::weeks(number_of_weeks)
-    #
-    #   data_no_signals <- data %>%
-    #     dplyr::filter(date_report <= cutoff_date)
-    #
-    # available_thresholds <- c(26, 20, 14, 8, 2)
-    #
-    # for (timeopt in available_thresholds) {
-    #   max_time_opt <- timeopt
-    #
-    #   signals_timeopt <- SignalDetectionTool::get_signals(
-    #     data_no_signals,
-    #     method = method,
-    #     number_of_weeks = timeopt + number_of_weeks,
-    #     alpha_upper = alpha_upper,
-    #     date_ext = date_ext - lubridate::weeks(number_of_weeks)
-    #   )
-    #
-    #   if (!is.null(signals_timeopt)) {
-    #     break
-    #   }
-    # }
-    # } else {
-    #     data_no_signals <- data
-    #
-    #      available_thresholds <- c(26, 20, 14, 8, 2)
-    #
-    #     for (timeopt in available_thresholds) {
-    #       max_time_opt <- timeopt
-    #
-    #       signals_timeopt <- SignalDetectionTool::get_signals(
-    #         data_no_signals,
-    #         method = method,
-    #         number_of_weeks = timeopt + number_of_weeks,
-    #         alpha_upper = alpha_upper,
-    #         date_ext = date_ext - lubridate::weeks(number_of_weeks)
-    #       )
-    #
-    #       if (!is.null(signals_timeopt)) {
-    #         break
-    #       }
-    #     }
-    #   }
-    # }
+  } else if(!is.null(date_ext)){
+
+    # also look at filters?
+    if ((date_ext - lubridate::weeks(number_of_weeks)) < max(data$date_report, na.rm = TRUE)) {
+      diff_weeks <- as.numeric(
+        lubridate::interval(date_ext - lubridate::weeks(number_of_weeks),
+                 max(data$date_report, na.rm = TRUE)) / lubridate::days(7)
+      )
+      cutoff_date <- max(data$date_report, na.rm = TRUE) - lubridate::weeks(number_of_weeks) + lubridate::weeks(diff_weeks) # to do: round correctly
+
+      data_no_signals <- data %>%
+        dplyr::filter(date_report <= cutoff_date)
+
+    available_thresholds <- c(26, 20, 14, 8, 2)
+
+    for (timeopt in available_thresholds) {
+      max_time_opt <- timeopt
+
+      signals_timeopt <- SignalDetectionTool::get_signals(
+        data_no_signals,
+        method = method,
+        number_of_weeks = timeopt + number_of_weeks,
+        alpha_upper = alpha_upper,
+        date_ext = date_ext - lubridate::weeks(number_of_weeks)
+      )
+
+      if (!is.null(signals_timeopt)) {
+        break
+      }
+    }
+    } else { # To do; is it rational to use the historic threshold option here?
+        data_no_signals <- data
+
+         available_thresholds <- c(26, 20, 14, 8, 2)
+
+        for (timeopt in available_thresholds) {
+          max_time_opt <- timeopt
+
+          signals_timeopt <- SignalDetectionTool::get_signals(
+            data_no_signals,
+            method = method,
+            number_of_weeks = timeopt + number_of_weeks,
+            alpha_upper = alpha_upper,
+            date_ext = date_ext - lubridate::weeks(number_of_weeks)
+          )
+
+          if (!is.null(signals_timeopt)) {
+            break
+          }
+        }
+      }
+    }
 
   result_padding_unstratified <- signals_timeopt %>%
     dplyr::select(year, week, category, stratum, upperbound_pad = upperbound, expected_pad = expected)
+
+  # TO DO: STRATIFICATION
 
   # preparing dataset with padding
   if (is.null(stratification)) {

--- a/R/get_signals.R
+++ b/R/get_signals.R
@@ -454,12 +454,12 @@ get_signals <- function(data,
         number_of_weeks = number_of_weeks,
         alpha_upper = alpha_upper
       )
-  }
 
-  # add extension date information if available
-  if (!is.null(date_ext)) {
-    results <- results %>%
-      dplyr::mutate(extension_date = date_ext)
+    # add extension date information if available
+    if (!is.null(date_ext)) {
+      results <- results %>%
+        dplyr::mutate(extension_date = date_ext)
+    }
   }
 
   return(results)
@@ -557,7 +557,6 @@ aggregate_signals <- function(signals, number_of_weeks) {
 #' Inside the function it is computed what the maximum number of timepoints is the signal detection algorithms can be applied for. This depends on the algorithm and the amount of historic data. The already generated signals dataframe is then extended with the expectation and threshold into the past
 #' @param data A data frame containing the surveillance data preprocessed with [preprocess_data()].
 #' @param signals tibble, output of the \code{\link{get_signals}} function with number of cases and signal per week, year
-#' @param date_var a character specifying the date variable name used for the aggregation. Default is "date_report".
 #' @returns tibble, with padded signals
 #' @examples
 #' \dontrun{
@@ -569,8 +568,7 @@ aggregate_signals <- function(signals, number_of_weeks) {
 #' }
 #' @export
 pad_signals <- function(data,
-                        signals,
-                        date_var = "date_report") {
+                        signals) {
   # get the stratification, method and number_of_weeks from the signals data
   stratification <- if (all(is.na(signals$category))) {
     NULL
@@ -603,10 +601,10 @@ pad_signals <- function(data,
   stopifnot(is.null(date_ext) || length(date_ext) == 1)
 
   if (is.null(date_ext)) {
-    cutoff_date <- max(data[[date_var]], na.rm = TRUE) - lubridate::weeks(number_of_weeks)
+    cutoff_date <- max(data$date_report, na.rm = TRUE) - lubridate::weeks(number_of_weeks)
 
     data_no_signals <- data %>%
-      dplyr::filter(.data[[date_var]] <= cutoff_date)
+      dplyr::filter(date_report <= cutoff_date)
 
     available_thresholds <- c(26, 20, 14, 8, 2)
 
@@ -626,18 +624,18 @@ pad_signals <- function(data,
       }
     }
   } else if (!is.null(date_ext)) {
-    if ((date_ext - lubridate::weeks(number_of_weeks)) < max(data[[date_var]], na.rm = TRUE)) {
+    if ((date_ext - lubridate::weeks(number_of_weeks)) < max(data$date_report, na.rm = TRUE)) {
       diff_weeks <- as.numeric(
         lubridate::interval(
           date_ext - lubridate::weeks(number_of_weeks),
-          max(data[[date_var]], na.rm = TRUE)
+          max(data$date_report, na.rm = TRUE)
         ) / lubridate::days(7)
       )
       diff_weeks <- floor(diff_weeks)
-      cutoff_date <- max(data[[date_var]], na.rm = TRUE) - lubridate::weeks(number_of_weeks) + lubridate::weeks(diff_weeks)
+      cutoff_date <- max(data$date_report, na.rm = TRUE) - lubridate::weeks(diff_weeks)
 
       data_no_signals <- data %>%
-        dplyr::filter(.data[[date_var]] <= cutoff_date)
+        dplyr::filter(date_report <= cutoff_date)
 
       available_thresholds <- c(26, 20, 14, 8, 2)
 
@@ -649,7 +647,7 @@ pad_signals <- function(data,
           method = method,
           number_of_weeks = timeopt + number_of_weeks,
           alpha_upper = alpha_upper,
-          date_ext = date_ext - lubridate::weeks(number_of_weeks)
+          date_ext = NULL
         )
 
         if (!is.null(signals_timeopt)) {

--- a/R/get_signals.R
+++ b/R/get_signals.R
@@ -557,6 +557,7 @@ aggregate_signals <- function(signals, number_of_weeks) {
 #' Inside the function it is computed what the maximum number of timepoints is the signal detection algorithms can be applied for. This depends on the algorithm and the amount of historic data. The already generated signals dataframe is then extended with the expectation and threshold into the past
 #' @param data A data frame containing the surveillance data preprocessed with [preprocess_data()].
 #' @param signals tibble, output of the \code{\link{get_signals}} function with number of cases and signal per week, year
+#' @param date_var a character specifying the date variable name used for the aggregation. Default is "date_report".
 #' @returns tibble, with padded signals
 #' @examples
 #' \dontrun{
@@ -568,7 +569,8 @@ aggregate_signals <- function(signals, number_of_weeks) {
 #' }
 #' @export
 pad_signals <- function(data,
-                        signals) {
+                        signals,
+                        date_var = "date_report") {
   # get the stratification, method and number_of_weeks from the signals data
   stratification <- if (all(is.na(signals$category))) {
     NULL
@@ -601,10 +603,10 @@ pad_signals <- function(data,
   stopifnot(is.null(date_ext) || length(date_ext) == 1)
 
   if (is.null(date_ext)){
-  cutoff_date <- max(data$date_report, na.rm = TRUE) - lubridate::weeks(number_of_weeks)
+  cutoff_date <- max(data[[date_var]], na.rm = TRUE) - lubridate::weeks(number_of_weeks)
 
   data_no_signals <- data %>%
-    dplyr::filter(date_report <= cutoff_date)
+    dplyr::filter(.data[[date_var]] <= cutoff_date)
 
   available_thresholds <- c(26, 20, 14, 8, 2)
 
@@ -626,15 +628,16 @@ pad_signals <- function(data,
   } else if(!is.null(date_ext)){
 
     # also look at filters?
-    if ((date_ext - lubridate::weeks(number_of_weeks)) < max(data$date_report, na.rm = TRUE)) {
+    if ((date_ext - lubridate::weeks(number_of_weeks)) < max(data[[date_var]], na.rm = TRUE)) {
       diff_weeks <- as.numeric(
         lubridate::interval(date_ext - lubridate::weeks(number_of_weeks),
-                 max(data$date_report, na.rm = TRUE)) / lubridate::days(7)
+                 max(data[[date_var]], na.rm = TRUE)) / lubridate::days(7)
       )
-      cutoff_date <- max(data$date_report, na.rm = TRUE) - lubridate::weeks(number_of_weeks) + lubridate::weeks(diff_weeks) # to do: round correctly
+      diff_weeks <- floor(diff_weeks)
+      cutoff_date <- max(data[[date_var]], na.rm = TRUE) - lubridate::weeks(number_of_weeks) + lubridate::weeks(diff_weeks) # to do: round correctly
 
       data_no_signals <- data %>%
-        dplyr::filter(date_report <= cutoff_date)
+        dplyr::filter(.data[[date_var]] <= cutoff_date)
 
     available_thresholds <- c(26, 20, 14, 8, 2)
 

--- a/R/mod_tabpanel_input.R
+++ b/R/mod_tabpanel_input.R
@@ -229,11 +229,18 @@ mod_tabpanel_input_server <- function(id, data, errors_detected) {
       shiny::req(input$n_weeks)
       shiny::req(iv_weeks$is_valid())
 
+      # Use extension date if available, otherwise latest date in filtered data
+      max_date_dataset <- if (!is.null(date_ext())) {
+        date_ext()
+      } else {
+        max(filtered_data()$date_report, na.rm = TRUE)
+      }
+
       # subtracting 1 from input$n_weeks to get correct dates for flooring (issue #256)
-      date_floor <- lubridate::floor_date(max(filtered_data()$date_report) - lubridate::weeks(input$n_weeks - 1),
+      date_floor <- lubridate::floor_date(max_date_dataset - lubridate::weeks(input$n_weeks - 1),
         week_start = 1, unit = "week"
       )
-      date_ceil <- lubridate::ceiling_date(max(filtered_data()$date_report), unit = "week", week_start = 7)
+      date_ceil <- lubridate::ceiling_date(max_date_dataset, unit = "week", week_start = 7)
       paste("Chosen signal detection period from", date_floor, "to", date_ceil)
     })
 

--- a/man/pad_signals.Rd
+++ b/man/pad_signals.Rd
@@ -5,12 +5,14 @@
 \title{Extend the computed threshold and expectation of the signal detection method to the past for visualisation purposes but not for signal generation
 Inside the function it is computed what the maximum number of timepoints is the signal detection algorithms can be applied for. This depends on the algorithm and the amount of historic data. The already generated signals dataframe is then extended with the expectation and threshold into the past}
 \usage{
-pad_signals(data, signals)
+pad_signals(data, signals, date_var = "date_report")
 }
 \arguments{
 \item{data}{A data frame containing the surveillance data preprocessed with [preprocess_data()].}
 
 \item{signals}{tibble, output of the \code{\link{get_signals}} function with number of cases and signal per week, year}
+
+\item{date_var}{a character specifying the date variable name used for the aggregation. Default is "date_report".}
 }
 \value{
 tibble, with padded signals

--- a/man/pad_signals.Rd
+++ b/man/pad_signals.Rd
@@ -5,14 +5,12 @@
 \title{Extend the computed threshold and expectation of the signal detection method to the past for visualisation purposes but not for signal generation
 Inside the function it is computed what the maximum number of timepoints is the signal detection algorithms can be applied for. This depends on the algorithm and the amount of historic data. The already generated signals dataframe is then extended with the expectation and threshold into the past}
 \usage{
-pad_signals(data, signals, date_var = "date_report")
+pad_signals(data, signals)
 }
 \arguments{
 \item{data}{A data frame containing the surveillance data preprocessed with [preprocess_data()].}
 
 \item{signals}{tibble, output of the \code{\link{get_signals}} function with number of cases and signal per week, year}
-
-\item{date_var}{a character specifying the date variable name used for the aggregation. Default is "date_report".}
 }
 \value{
 tibble, with padded signals


### PR DESCRIPTION
This draft changes the computation of the historic threshold and/or expectation so that both are derived from the extended dataframe over the full time range.

One open issue remains: the historic threshold may still appear in the first week of the testing period. The implementation should be checked for all supported signal detection algorithms to confirm that the extended time range is handled consistently.