### PR TITLE
[Fix] Cusum with low case numbers

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,4 @@
+* Fix padding of signals with cusum. Strata with very low number of cases would have no cases in the training period, which caused the signal function to find an error.
 * fix missing display of expectation and/or threshold for historic data when using an extension date with FarringtonFlexible, EARS and CUSUM
 * Added option to exclude outbreak-associated cases from baseline fitting for GLM-based algorithms
 * Added visualisation of age group comparison of cases in signal vs. cases from the signal detection period in the linelist tab

--- a/R/cusum.R
+++ b/R/cusum.R
@@ -41,6 +41,11 @@ get_signals_cusum <- function(data_aggregated,
     return(NULL)
   }
 
+  # cusum not posible if there are no cases in the calibration weeks
+  if(sum(sts_cases@observed[1:num_weeks_for_calibration]) <= 0){
+    return(NULL)
+  }
+
   control <- list(
     range = ((num_weeks_total - number_of_weeks + 1):num_weeks_total),
     k = 1.04,

--- a/R/cusum.R
+++ b/R/cusum.R
@@ -42,7 +42,7 @@ get_signals_cusum <- function(data_aggregated,
   }
 
   # cusum not posible if there are no cases in the calibration weeks
-  if(sum(sts_cases@observed[1:num_weeks_for_calibration]) <= 0){
+  if (sum(sts_cases@observed[1:num_weeks_for_calibration]) <= 0) {
     return(NULL)
   }
 

--- a/man/algo.cusum_with_reset.Rd
+++ b/man/algo.cusum_with_reset.Rd
@@ -49,14 +49,6 @@ algo.cusum_with_reset(
                 }
               }
               \item{\code{alpha}}{parameter of the negative binomial distribution, s.t. the variance is \eqn{m+\alpha *m^2} }
-              \item{\code{reset}}{
-                logical: Should the CUSUM statistic be reset to 0
-                immediately after an alarm? This is the traditional form
-                of the chart as used in industrial process control,
-                but not the default choice in outbreak detection when
-                continuous periods of abnormal disease activity should
-                be flagged.
-              }
         }
       }
 }

--- a/man/cusum_with_reset.Rd
+++ b/man/cusum_with_reset.Rd
@@ -50,14 +50,6 @@ cusum_with_reset(
                 }
               }
               \item{\code{alpha}}{parameter of the negative binomial distribution, s.t. the variance is \eqn{m+\alpha *m^2} }
-              \item{\code{reset}}{
-                logical: Should the CUSUM statistic be reset to 0
-                immediately after an alarm? This is the traditional form
-                of the chart as used in industrial process control,
-                but not the default choice in outbreak detection when
-                continuous periods of abnormal disease activity should
-                be flagged.
-              }
         }
       }
 

--- a/tests/testthat/test-cusum.R
+++ b/tests/testthat/test-cusum.R
@@ -1,16 +1,16 @@
 test_that("cusum with no cases in training period is skipped", {
   dat <- input_example %>%
-    filter_by_date(date_start = as.Date("2023-01-09")) %>% 
-    dplyr::filter(age_group %in% c("00-04", "15-19")) %>% 
+    filter_by_date(date_start = as.Date("2023-01-09")) %>%
+    dplyr::filter(age_group %in% c("00-04", "15-19")) %>%
     preprocess_data()
-   
-  dat_agg <- dat %>% 
+
+  dat_agg <- dat %>%
     aggregate_data(group = "age_group")
 
   # this groups has cases
   dat_0_4 <- dat_agg %>% dplyr::filter(age_group == "00-04")
   expect_no_error(get_signals_cusum(dat_0_4, number_of_weeks = 21))
-  
+
   # this groups has no cases between 2023-W2 to 2023-W8
   dat_15_19 <- dat_agg %>% dplyr::filter(age_group == "15-19")
   expect_null(get_signals_cusum(dat_15_19, number_of_weeks = 21))

--- a/tests/testthat/test-cusum.R
+++ b/tests/testthat/test-cusum.R
@@ -1,0 +1,23 @@
+test_that("cusum with no cases in training period is skipped", {
+  dat <- input_example %>%
+    filter_by_date(date_start = as.Date("2023-01-09")) %>% 
+    dplyr::filter(age_group %in% c("00-04", "15-19")) %>% 
+    preprocess_data()
+   
+  dat_agg <- dat %>% 
+    aggregate_data(group = "age_group")
+
+  # this groups has cases
+  dat_0_4 <- dat_agg %>% dplyr::filter(age_group == "00-04")
+  expect_no_error(get_signals_cusum(dat_0_4, number_of_weeks = 21))
+  
+  # this groups has no cases between 2023-W2 to 2023-W8
+  dat_15_19 <- dat_agg %>% dplyr::filter(age_group == "15-19")
+  expect_null(get_signals_cusum(dat_15_19, number_of_weeks = 21))
+
+  # warning from signal wrapper
+  expect_warning(
+    get_signals_all(dat, "cusum", stratification = "age_group", number_of_weeks = 21),
+    "The stratum age_group:15-19"
+  )
+})


### PR DESCRIPTION
I added a condition to skip cusum when no cases in the training data are found. This triggered bug #444 
Whenever we encounter this condition, a warning is returned saying the specific strata that was skipped. We can also discuss if it make sense to shorten the padding to avoid such scenarios with no cases in the historical data (Eg line 669 of get_signals.R)