### PR TITLE
fix handling of NA stratum in selected linelist tab

### DIFF
--- a/R/mod_tabpanel_linelist.R
+++ b/R/mod_tabpanel_linelist.R
@@ -145,9 +145,14 @@ mod_tabpanel_linelist_server <- function(
           )
 
         # further filtering if stratification was applied
-        if (!is.na(category) && !is.na(stratum)) {
-          filtered_df <- filtered_df %>%
-            dplyr::filter(!!sym(category) == stratum)
+        if (!is.na(category)) {
+          if (!is.na(stratum)) {
+            filtered_df <- filtered_df %>%
+              dplyr::filter(!!sym(category) == stratum)
+          } else { # unknown stratum can be NA for sex
+            filtered_df <- filtered_df %>%
+              dplyr::filter(is.na(!!sym(category)))
+          }
         }
 
         return(filtered_df)


### PR DESCRIPTION
resolves #469 

the problem was, the filtering of the linelist using the selected signals was done only when both category and stratum were not NA.  This was fine for most of the cases, where a stratified signal (eg sex) will have non na categories (eg male, female, or diverse). However, as the linelist stores unknown sex category as NA, this condition didn't work properly.
I added an extra condition for this specific cases.

I would like to add a test, but these functions work inside the app modules. Maybe a more robust approach would be to have the selecting and filtering functions under helpers.r, so we can create tests for them 