### PR TITLE
fix handling of NA stratum in selected linelist tab. add test

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 * Added option to exclude outbreak-associated cases from baseline fitting for GLM-based algorithms
 * Added visualisation of age group comparison of cases in signal vs. cases from the signal detection period in the linelist tab
 * Introduced a post-processing score for alarms to support priority-based filtering
+* Fixed bug in the selected signal calses in the linelist tab that handled NA stratum values wrongly.
 
 # SignalDetectionTool 0.10.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,7 @@
 * Added option to exclude outbreak-associated cases from baseline fitting for GLM-based algorithms
 * Added visualisation of age group comparison of cases in signal vs. cases from the signal detection period in the linelist tab
 * Introduced a post-processing score for alarms to support priority-based filtering
-* Fixed bug in the selected signal calses in the linelist tab that handled NA stratum values wrongly.
+* Fixed bug in linelist tab that handled NA stratum values wrongly for selected signals.
 
 # SignalDetectionTool 0.10.0
 

--- a/R/linelist_helpers.R
+++ b/R/linelist_helpers.R
@@ -11,9 +11,9 @@
 #' @param end_date End date of the reporting period. Rows with
 #'   `date_report <= end_date` are retained.
 #' @param signal_row Optional one-row data frame from the signal results
-#'   containing the columns `category` and `stratum`. If provided and both
-#'   values are not `NA`, the linelist is filtered to rows where the column
-#'   named in `category` equals `stratum`
+#'   containing the columns `category` and `stratum`. If provided, and the value
+#'   of `category` is not NA, the linelist is filtered to rows where the
+#'   column named in `category` equals `stratum`.
 #'
 #' @return A filtered data frame containing linelist rows within the selected
 #'   reporting period and, if applicable, the selected stratum.

--- a/R/linelist_helpers.R
+++ b/R/linelist_helpers.R
@@ -31,9 +31,14 @@ filter_linelist_by_period_and_stratum <- function(linelist, start_date, end_date
   if (!is.null(signal_row)) {
     category <- signal_row$category
     stratum <- signal_row$stratum
-    if (!is.na(category) && !is.na(stratum)) {
-      filtered_df <- filtered_df %>%
-        dplyr::filter(!!rlang::sym(category) == stratum)
+    if (!is.na(category)) {
+      if (!is.na(stratum)) {
+        filtered_df <- filtered_df %>%
+          dplyr::filter(!!sym(category) == stratum)
+      } else { # unknown stratum can be NA for sex
+        filtered_df <- filtered_df %>%
+          dplyr::filter(is.na(!!sym(category)))
+      }
     }
   }
 

--- a/man/filter_linelist_by_period_and_stratum.Rd
+++ b/man/filter_linelist_by_period_and_stratum.Rd
@@ -22,9 +22,9 @@ Must contain a `date_report` column.}
 `date_report <= end_date` are retained.}
 
 \item{signal_row}{Optional one-row data frame from the signal results
-containing the columns `category` and `stratum`. If provided and both
-values are not `NA`, the linelist is filtered to rows where the column
-named in `category` equals `stratum`}
+containing the columns `category` and `stratum`. If provided, and the value
+of `category` is not NA, the linelist is filtered to rows where the
+column named in `category` equals `stratum`.}
 }
 \value{
 A filtered data frame containing linelist rows within the selected

--- a/tests/testthat/test-linelist_helpers.R
+++ b/tests/testthat/test-linelist_helpers.R
@@ -222,7 +222,7 @@ test_that("build_signal_and_comparison_linelist selects cases with unknown sex",
     time_unit = c("weekly", "weekly")
   )
 
-   signals_padded <- data.frame(
+  signals_padded <- data.frame(
     year = c(rep(2023, 52), 2024, rep(2023, 52), 2024),
     week = c(seq(1, 52), 1, seq(1, 52), 1),
     cases = c(rep(5, 52), 13, rep(5, 52), 12),
@@ -290,7 +290,6 @@ test_that("build_signal_and_comparison_linelist selects cases with unknown sex",
       rep("2023-12-26", 10),
       rep("2024-01-02", 13),
       rep("2024-01-02", 12)
-
     )),
     sex = c(
       rep(c("male", NA_character_), 260),
@@ -309,5 +308,4 @@ test_that("build_signal_and_comparison_linelist selects cases with unknown sex",
   # selecting signal id 2, should give back the 12 unknown sex cases
   expect_equal(nrow(result$cases), 12)
   expect_false(any(result$cases_comparison$case_id %in% result$cases$case_id))
-
 })

--- a/tests/testthat/test-linelist_helpers.R
+++ b/tests/testthat/test-linelist_helpers.R
@@ -209,3 +209,105 @@ test_that("build_signal_and_comparison_linelist excludes selected signal cases f
     279:290
   )
 })
+
+test_that("build_signal_and_comparison_linelist selects cases with unknown sex", {
+  true_signals <- data.frame(
+    year = rep(2024, 2),
+    week = c(1, 1),
+    cases = c(13, 12),
+    category = c("sex", "sex"),
+    stratum = c("male", NA_character_),
+    alarms = c(TRUE, TRUE),
+    signal_id = c(1, 2),
+    time_unit = c("weekly", "weekly")
+  )
+
+   signals_padded <- data.frame(
+    year = c(rep(2023, 52), 2024, rep(2023, 52), 2024),
+    week = c(seq(1, 52), 1, seq(1, 52), 1),
+    cases = c(rep(5, 52), 13, rep(5, 52), 12),
+    alarms = c(rep(NA, 52), TRUE, rep(NA, 52), TRUE),
+    category = c(rep("sex", 53), rep("sex", 53)),
+    stratum = c(rep("male", 53), rep(NA_character_, 53)),
+    number_of_time_units = 1,
+    time_unit = "weekly"
+  )
+
+  filtered_data <- data.frame(
+    case_id = seq_len(545),
+    date_report = as.Date(c(
+      rep("2023-01-03", 10),
+      rep("2023-01-10", 10),
+      rep("2023-01-17", 10),
+      rep("2023-01-24", 10),
+      rep("2023-01-31", 10),
+      rep("2023-02-07", 10),
+      rep("2023-02-14", 10),
+      rep("2023-02-21", 10),
+      rep("2023-02-28", 10),
+      rep("2023-03-07", 10),
+      rep("2023-03-14", 10),
+      rep("2023-03-21", 10),
+      rep("2023-03-28", 10),
+      rep("2023-04-04", 10),
+      rep("2023-04-11", 10),
+      rep("2023-04-18", 10),
+      rep("2023-04-25", 10),
+      rep("2023-05-02", 10),
+      rep("2023-05-09", 10),
+      rep("2023-05-16", 10),
+      rep("2023-05-23", 10),
+      rep("2023-05-30", 10),
+      rep("2023-06-06", 10),
+      rep("2023-06-13", 10),
+      rep("2023-06-20", 10),
+      rep("2023-06-27", 10),
+      rep("2023-07-04", 10),
+      rep("2023-07-11", 10),
+      rep("2023-07-18", 10),
+      rep("2023-07-25", 10),
+      rep("2023-08-01", 10),
+      rep("2023-08-08", 10),
+      rep("2023-08-15", 10),
+      rep("2023-08-22", 10),
+      rep("2023-08-29", 10),
+      rep("2023-09-05", 10),
+      rep("2023-09-12", 10),
+      rep("2023-09-19", 10),
+      rep("2023-09-26", 10),
+      rep("2023-10-03", 10),
+      rep("2023-10-10", 10),
+      rep("2023-10-17", 10),
+      rep("2023-10-24", 10),
+      rep("2023-10-31", 10),
+      rep("2023-11-07", 10),
+      rep("2023-11-14", 10),
+      rep("2023-11-21", 10),
+      rep("2023-11-28", 10),
+      rep("2023-12-05", 10),
+      rep("2023-12-12", 10),
+      rep("2023-12-19", 10),
+      rep("2023-12-26", 10),
+      rep("2024-01-02", 13),
+      rep("2024-01-02", 12)
+
+    )),
+    sex = c(
+      rep(c("male", NA_character_), 260),
+      rep("male", 13),
+      rep(NA_character_, 12)
+    )
+  )
+
+  result <- build_signal_and_comparison_linelist(
+    selected_signal_ids = c(2),
+    true_signals = true_signals,
+    signals_padded = signals_padded,
+    filtered_data = filtered_data
+  )
+
+  # selecting signal id 2, should give back the 12 unknown sex cases
+  expect_equal(nrow(result$cases), 12)
+  expect_false(any(result$cases_comparison$case_id %in% result$cases$case_id))
+
+})


### PR DESCRIPTION
resolves #469 at the current development branch

the problem was, the filtering of the linelist using the selected signals was done only when both category and stratum were not NA. This was fine for most of the cases, where a stratified signal (eg sex) will have non na categories (eg male, female, or diverse). However, as the linelist stores unknown sex category as NA, this condition didn't work properly.
I added an extra condition for these specific cases, and a test in test-linelist_helpers.r