### PR TITLE
fix/no_signals_found

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+* Fix error when clicking "No signals found." in the app
+
 # SignalDetectionTool 0.11.0
 * Added visualisations and bug fixes in the linelist tab
   * Added visualisation of age group comparison of cases in signal vs. cases from the signal detection period.

--- a/R/plot_signal_cases_comparison.R
+++ b/R/plot_signal_cases_comparison.R
@@ -22,17 +22,17 @@ plot_agegroup_comparison <- function(data_agg, number_of_time_units, time_unit) 
   )
 
   if (any(data_agg$signal, na.rm = TRUE)) {
-  checkmate::assert_integerish(
-    number_of_time_units,
-    lower = 1,
-    len = 1
-  )
+    checkmate::assert_integerish(
+      number_of_time_units,
+      lower = 1,
+      len = 1
+    )
 
-  checkmate::assert_choice(
-    time_unit,
-    choices = c("weekly", "biweekly", "monthly"),
-    null.ok = FALSE
-  )
+    checkmate::assert_choice(
+      time_unit,
+      choices = c("weekly", "biweekly", "monthly"),
+      null.ok = FALSE
+    )
   }
 
   # Use time unit labels

--- a/R/plot_signal_cases_comparison.R
+++ b/R/plot_signal_cases_comparison.R
@@ -21,6 +21,7 @@ plot_agegroup_comparison <- function(data_agg, number_of_time_units, time_unit) 
     min.cols = 2
   )
 
+  if (any(data_agg$signal, na.rm = TRUE)) {
   checkmate::assert_integerish(
     number_of_time_units,
     lower = 1,
@@ -32,6 +33,7 @@ plot_agegroup_comparison <- function(data_agg, number_of_time_units, time_unit) 
     choices = c("weekly", "biweekly", "monthly"),
     null.ok = FALSE
   )
+  }
 
   # Use time unit labels
   time_unit_label <- dplyr::case_when(


### PR DESCRIPTION
This PR adjusts the validation of `number_of_time_units` and `time_unit` so that it is only performed when `data_agg` contains at least one signal (`signal == TRUE`). This prevents unnecessary validation errors when no signals are present.

The previously observed `ISOweek::ISOweek2date()` warning/error seems like it was already no longer an issue in the current version prior to this change. Please also check this.