### PR TITLE
fix/skeewed maps 

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 * Fix error when clicking "No signals found." in the app
 * Updated min required version for "surveillance" package to v1.25.0
+* Fixed bug that caused skewed map plots of certain regions
 
 # SignalDetectionTool 0.11.0
 * Added visualisations and bug fixes in the linelist tab

--- a/R/plot_regional.R
+++ b/R/plot_regional.R
@@ -133,7 +133,7 @@ plot_regional <- function(shape_with_signals,
 
   if (interactive) {
     shape_areas_sf <- shape_with_signals %>%
-      sf::st_transform(4326) %>% 
+      sf::st_transform(4326) %>%
       dplyr::filter(!sf::st_is_empty(geometry)) %>%
       sf::st_make_valid() %>%
       sf::st_collection_extract("POLYGON", warn = FALSE) %>%

--- a/R/plot_regional.R
+++ b/R/plot_regional.R
@@ -133,6 +133,7 @@ plot_regional <- function(shape_with_signals,
 
   if (interactive) {
     shape_areas_sf <- shape_with_signals %>%
+      sf::st_transform(4326) %>% 
       dplyr::filter(!sf::st_is_empty(geometry)) %>%
       sf::st_make_valid() %>%
       sf::st_collection_extract("POLYGON", warn = FALSE) %>%
@@ -161,7 +162,7 @@ plot_regional <- function(shape_with_signals,
         inherit = FALSE
       )
 
-    stars_sf <- shape_with_signals %>%
+    stars_sf <- shape_areas_sf %>%
       dplyr::filter(any_alarms == "At least 1 signal")
     nrow_stars_before <- nrow(stars_sf)
 
@@ -173,7 +174,7 @@ plot_regional <- function(shape_with_signals,
       # calculate centre robustly
       stars_sf <- stars_sf %>%
         sf::st_make_valid() %>%
-        sf::st_centroid(of_largest_polygon = TRUE) %>%
+        sf::st_centroid() %>%
         sf::st_collection_extract("POINT") %>% # only keep points
         dplyr::filter(!sf::st_is_empty(geometry)) # remove empty ones
 


### PR DESCRIPTION
To my understanding, the shapefiles contain a coordinate ref system that needs to be converted so the plotly function  `add_sf()` understand the coordinates correctly and plots without skewness. Other plotly functions like `plot_ly(type = "choropleth")` don't accept the shapefile as we have it, but requires a geojson version. Moritz tried this solution solving the error but also decrased performance (see STATO-66)

I tried with all Bundesländer and skewness seem to be solved everywhere (left original, right this solution), but cannot test what would happen with other types of shapefiles (europe-wide) or if the coordinate transform would work in general for all

<img width="649" height="448" alt="BB" src="https://github.com/user-attachments/assets/30ef708e-b0ff-4694-a846-342ced5a052d" />
<img width="649" height="448" alt="BE" src="https://github.com/user-attachments/assets/dd0fed51-702d-4587-918b-20d651f3583e" />
<img width="649" height="448" alt="BW" src="https://github.com/user-attachments/assets/adb65617-cf0e-463f-9a07-a22cdc28146d" />
<img width="649" height="448" alt="BY" src="https://github.com/user-attachments/assets/ad63a3c8-2af5-4294-943e-f0364e14e5c7" />
<img width="649" height="448" alt="HB" src="https://github.com/user-attachments/assets/a6e96e55-0857-475b-96bd-7ea8fab35e19" />
<img width="649" height="448" alt="HE" src="https://github.com/user-attachments/assets/175e8151-d8e2-4f4d-92c6-6750285846de" />
<img width="649" height="448" alt="HH" src="https://github.com/user-attachments/assets/10f6b070-b79b-424d-aec5-412fdc7bbb51" />
<img width="649" height="448" alt="MV" src="https://github.com/user-attachments/assets/2e694ad2-c3c5-45b6-8777-043c6207aded" />
<img width="649" height="448" alt="NI" src="https://github.com/user-attachments/assets/6f4b3659-496d-4d04-b4cd-2ec730147d6e" />
<img width="649" height="448" alt="NW" src="https://github.com/user-attachments/assets/45ae40c7-13aa-49f4-81d2-a3f53660b51b" />
<img width="649" height="448" alt="RP" src="https://github.com/user-attachments/assets/6ffc5dc9-3560-4431-9279-de477327ce0a" />
<img width="649" height="448" alt="SH" src="https://github.com/user-attachments/assets/efdd1053-64d6-419e-af35-be552c398713" />
<img width="649" height="448" alt="SL" src="https://github.com/user-attachments/assets/4f77ec1f-fdd6-4a24-aec3-75973c4db547" />
<img width="649" height="448" alt="SN" src="https://github.com/user-attachments/assets/5bb3c6c0-53eb-479a-9d84-dec4f5ac1b1d" />
<img width="649" height="448" alt="ST" src="https://github.com/user-attachments/assets/e8bf3b32-296f-41b2-a1eb-965d9b011aa2" />
<img width="649" height="448" alt="TH" src="https://github.com/user-attachments/assets/38b69f3a-4477-41a2-9438-5f0609084650" />
